### PR TITLE
don't add notes to the diagram if the request/response content is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 /src/NewDay.Platform.Identity.Provider/keys
+
+# JetBrains Rider
+.idea/

--- a/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
+++ b/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
@@ -62,10 +62,15 @@ public class PlantUmlCreator
                 requestPlantUmlNoteContent = processor.Invoke(requestPlantUmlNoteContent);
 
                 plantUml +=
-                    $"{callerShortName} -> {serviceShortName}: {trace.Method}: {trace.Uri.PathAndQuery}{Environment.NewLine}" +
-                    $"note left{Environment.NewLine}" +
-                    $"{requestPlantUmlNoteContent}{Environment.NewLine}" +
-                    $"end note{Environment.NewLine}";
+                    $"{callerShortName} -> {serviceShortName}: {trace.Method}: {trace.Uri.PathAndQuery}{Environment.NewLine}";
+
+                if (!string.IsNullOrEmpty(requestPlantUmlNoteContent))
+                {
+                    plantUml +=
+                        $"note left{Environment.NewLine}" +
+                        $"{requestPlantUmlNoteContent}{Environment.NewLine}" +
+                        $"end note{Environment.NewLine}";
+                }
             }
 
             if (trace.Type == RequestResponseType.Response)
@@ -76,10 +81,15 @@ public class PlantUmlCreator
                 responsePlantUmlNoteContent = processor.Invoke(responsePlantUmlNoteContent);
 
                 plantUml +=
-                    $"{serviceShortName} --> {callerShortName}: {trace.StatusCode.ToString().Titleize()}{Environment.NewLine}" +
-                    $"note right{Environment.NewLine}" +
-                    $"{responsePlantUmlNoteContent}{Environment.NewLine}" +
-                    $"end note{Environment.NewLine}";
+                    $"{serviceShortName} --> {callerShortName}: {trace.StatusCode.ToString().Titleize()}{Environment.NewLine}";
+
+                if (!string.IsNullOrEmpty(responsePlantUmlNoteContent))
+                {
+                    plantUml +=
+                        $"note right{Environment.NewLine}" +
+                        $"{responsePlantUmlNoteContent}{Environment.NewLine}" +
+                        $"end note{Environment.NewLine}";
+                }
             }
         }
 


### PR DESCRIPTION
This will prevent empty notes being output to the diagram, for example:

Empty response:
![image](https://github.com/lemonlion/TestTrackingDiagrams/assets/136344532/8b62fc6b-4ac6-46b1-84d8-ee5c23cc6b46)

Empty request and empty response:
![image](https://github.com/lemonlion/TestTrackingDiagrams/assets/136344532/4f0cd0a6-cd24-4e2e-9b97-aca67488a031)
