### PR TITLE
Order headers when outputting them to the PlantUML diagram

### DIFF
--- a/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
+++ b/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
@@ -194,7 +194,8 @@ skinparam wrapWidth {MaxLineWidth}{Environment.NewLine}
 
         return (($"{string.Join(Environment.NewLine, headers
             .Where(y => !excludedHeaders.Contains(y.Key))
-            .SelectMany(y => BatchGray($"[{y.Key}={y.Value}]")) 
+            .OrderBy(y => y.Key)
+            .SelectMany(y => BatchGray($"[{y.Key}={y.Value}]"))
         )}" + Environment.NewLine).TrimStart() +
                 Environment.NewLine +
                 $"{parsedContent}".Trim()).Trim();


### PR DESCRIPTION
Makes a specific header easier to locate in the PlantUML diagram when the response/request contains multiple headers. Provides a guarantee that headers will always appear in a consistent order.