### PR TITLE
#14 setup separation

### DIFF
--- a/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
@@ -54,7 +54,8 @@ public class BDDfyTestSetup : IAsyncLifetime
 
         BDDfyReportGenerator.CreateStandardReportsWithDiagrams(new ReportConfigurationOptions
         {
-            SpecificationsTitle = "Dessert Provider Specifications"
+            SpecificationsTitle = "Dessert Provider Specifications",
+            SeparateSetup = true,
         });
 
         DisposeHttpFakes();

--- a/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5036"
+  "CowServiceBaseUrl": "http://localhost:15036"
 }

--- a/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/ConfiguredLightBddScopeAttribute.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/ConfiguredLightBddScopeAttribute.cs
@@ -27,7 +27,8 @@ internal class ConfiguredLightBddScopeAttribute : LightBddScopeAttribute
         configuration.ReportWritersConfiguration().CreateStandardReportsWithDiagrams(testAssembly,
             new ReportConfigurationOptions
             {
-                SpecificationsTitle = "Dessert Provider Specifications"
+                SpecificationsTitle = "Dessert Provider Specifications",
+                SeparateSetup = true,
             });
 
         // To stop the output repeating the step name for each step

--- a/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5033"
+  "CowServiceBaseUrl": "http://localhost:15033"
 }

--- a/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/TestRun.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/TestRun.cs
@@ -34,6 +34,7 @@ public class TestRun : DiagrammedTestRun
             new ReportConfigurationOptions
             {
                 SpecificationsTitle = "Dessert Provider Specifications",
+                SeparateSetup = true,
             });
 
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.NUnit4/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.NUnit4/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5032"
+  "CowServiceBaseUrl": "http://localhost:15032"
 }

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
@@ -61,7 +61,8 @@ public class TestSetupHooks
     {
         ReqNRollReportGenerator.CreateStandardReportsWithDiagrams(new ReportConfigurationOptions
         {
-            SpecificationsTitle = "Dessert Provider Specifications"
+            SpecificationsTitle = "Dessert Provider Specifications",
+            SeparateSetup = true,
         });
 
         DisposeHttpFakes();

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5034"
+  "CowServiceBaseUrl": "http://localhost:15034"
 }

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
@@ -61,7 +61,8 @@ public class TestSetupHooks
     {
         ReqNRollReportGenerator.CreateStandardReportsWithDiagrams(new ReportConfigurationOptions
         {
-            SpecificationsTitle = "Dessert Provider Specifications"
+            SpecificationsTitle = "Dessert Provider Specifications",
+            SeparateSetup = true,
         });
 
         DisposeHttpFakes();

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5035"
+  "CowServiceBaseUrl": "http://localhost:15035"
 }

--- a/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/TestRun.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/TestRun.cs
@@ -26,6 +26,7 @@ public class TestRun : DiagrammedTestRun, IDisposable
             new ReportConfigurationOptions
             {
                 SpecificationsTitle = "Dessert Provider Specifications",
+                SeparateSetup = true,
             });
 
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.XUnit/appsettings.componenttests.json
+++ b/Example.Api/tests/Example.Api.Tests.Component.XUnit/appsettings.componenttests.json
@@ -1,3 +1,3 @@
 {
-  "CowServiceBaseUrl": "http://localhost:5031"
+  "CowServiceBaseUrl": "http://localhost:15031"
 }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Effortlessly autogenerate **PlantUML sequence diagrams** from your component and
   - [StartOverride / EndOverride](#override-start-end)
   - [InsertPlantUml](#override-insert)
   - [InsertTestDelimiter](#override-delimiter)
+  - [StartAction](#override-start-action)
+  - [Setup Separation](#setup-separation)
 - [Content Formatting](#content-formatting)
   - [DiagramsFetcherOptions](#fetcher-options)
   - [Pre- and Post-Formatting Processors](#formatting-processors)
@@ -463,7 +465,9 @@ new ReportConfigurationOptions
     ReportsFolderPath = "Reports",
     ExcludedHeaders = ["Authorization", "X-Api-Key"],
     HtmlSpecificationsCustomStyleSheet = "body { font-family: sans-serif; }",
-    RequestResponsePostProcessor = content => content.Replace("secret", "***")
+    RequestResponsePostProcessor = content => content.Replace("secret", "***"),
+    SeparateSetup = true,
+    HighlightSetup = true
 }
 ```
 
@@ -478,6 +482,8 @@ new ReportConfigurationOptions
 | `ReportsFolderPath` | `string` | `"Reports"` | Folder path (relative to `AppDomain.CurrentDomain.BaseDirectory`) where reports are written. |
 | `ExcludedHeaders` | `string[]` | `[]` | HTTP headers to exclude from diagram notes. Combined with `PlantUmlCreator.DefaultExcludedHeaders` (`Cache-Control`, `Pragma`). |
 | `RequestResponsePostProcessor` | `Func<string, string>?` | `null` | Post-processing function applied to both request and response content before rendering in diagrams. Useful for redacting sensitive data. |
+| `SeparateSetup` | `bool` | `false` | When `true`, HTTP calls made before `StartAction()` (or before the first non-GIVEN BDD step) are wrapped in a visual "Setup" partition in the diagram. See [Setup Separation](#setup-separation). |
+| `HighlightSetup` | `bool` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour. When `false`, the partition has no background colour. Has no effect when `SeparateSetup` is `false`. |
 
 ---
 
@@ -494,6 +500,7 @@ TrackingDiagramOverride.StartOverride(plantUml?);
 TrackingDiagramOverride.EndOverride(plantUml?);
 TrackingDiagramOverride.InsertPlantUml(plantUml);
 TrackingDiagramOverride.InsertTestDelimiter(testIdentifier);
+TrackingDiagramOverride.StartAction();
 ```
 
 ### <a name="override-start-end"></a>StartOverride / EndOverride [↑](#top)
@@ -534,6 +541,48 @@ This renders as a black horizontal note across all participants with white text 
 
 > **LightBDD tip:** This is particularly useful when using LightBDD's [Tabular Parameters](https://github.com/LightBDD/LightBDD/wiki/Advanced-Step-Parameters#tabular-parameters) or [TabularAttributes](https://github.com/lemonlion/LightBdd.TabularAttributes), where a single scenario runs multiple iterations. Insert a delimiter between each iteration to clearly separate them in the diagram.
 
+### <a name="override-start-action"></a>StartAction [↑](#top)
+
+Explicitly mark the boundary between setup and action phases of a test. When `SeparateSetup` is enabled, all HTTP calls before `StartAction()` are rendered inside a "Setup" partition in the diagram:
+
+```csharp
+// Setup phase — these calls appear inside the partition
+await client.PostAsync("/api/seed-data", content);
+await client.PostAsync("/api/configure", settings);
+
+TrackingDiagramOverride.StartAction();
+
+// Action phase — these calls appear after the partition
+var response = await client.GetAsync("/api/cake");
+```
+
+> **BDD frameworks (LightBDD, ReqNRoll):** `StartAction()` is called automatically when the test transitions from a GIVEN step to a WHEN or THEN step. You only need to call it explicitly if you want to override the automatic detection or are using a non-BDD framework.
+
+### <a name="setup-separation"></a>Setup Separation [↑](#top)
+
+Setup separation visually distinguishes the "arrange" phase of a test from the "act" phase in the generated sequence diagrams by wrapping setup HTTP calls in a PlantUML partition block.
+
+To enable it, set `SeparateSetup = true` on `ReportConfigurationOptions`:
+
+```csharp
+new ReportConfigurationOptions
+{
+    SeparateSetup = true,
+    HighlightSetup = true // default — adds a background colour to the partition
+}
+```
+
+| Property | Effect |
+|---|---|
+| `SeparateSetup = false` | No partition — all calls rendered sequentially (default) |
+| `SeparateSetup = true, HighlightSetup = true` | Setup calls wrapped in a coloured partition |
+| `SeparateSetup = true, HighlightSetup = false` | Setup calls wrapped in a plain partition (no background colour) |
+
+The boundary between setup and action is determined by:
+
+1. **Explicit** — Call `TrackingDiagramOverride.StartAction()` in your test code
+2. **Implicit (BDD frameworks)** — Automatically detected when the test transitions from a GIVEN step to a WHEN or THEN step (supported in LightBDD and ReqNRoll)
+
 ---
 
 ## <a name="content-formatting"></a>Content Formatting [↑](#top)
@@ -562,6 +611,8 @@ var options = new DiagramsFetcherOptions
 | `ResponsePreFormattingProcessor` | `Func<string, string>?` | `null` | Transform raw response body **before** the library formats it into the PlantUML note. |
 | `ResponsePostFormattingProcessor` | `Func<string, string>?` | `null` | Transform the formatted response note **after** the library has formatted it. |
 | `ExcludedHeaders` | `IEnumerable<string>` | `[]` | HTTP headers to exclude from diagram notes. |
+| `SeparateSetup` | `bool` | `false` | When `true`, HTTP calls made before `StartAction()` are wrapped in a visual "Setup" partition in the diagram. See [Setup Separation](#setup-separation). |
+| `HighlightSetup` | `bool` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour. When `false`, the partition has no background colour. |
 
 ### <a name="formatting-processors"></a>Pre- and Post-Formatting Processors [↑](#top)
 
@@ -728,11 +779,11 @@ Then browse to `tests\<project>\bin\Debug\net8.0\Reports\` to view the generated
 
 | Class / Record | Description |
 |---|---|
-| `ReportConfigurationOptions` | Configuration for report file names, titles, PlantUML server, excluded headers, and custom stylesheets. |
-| `DiagramsFetcherOptions` | Configuration for diagram content formatting processors and header exclusions. |
+| `ReportConfigurationOptions` | Configuration for report file names, titles, PlantUML server, excluded headers, setup separation, and custom stylesheets. |
+| `DiagramsFetcherOptions` | Configuration for diagram content formatting processors, header exclusions, and setup separation. |
 | `DefaultDiagramsFetcher` | Static class; `GetDiagramsFetcher(options?)` returns a `Func<DiagramAsCode[]>` that fetches all generated diagrams. |
 | `DefaultDiagramsFetcher.DiagramAsCode` | Record containing `TestRuntimeId`, `ImgSrc` (rendered PNG URL), and `CodeBehind` (raw PlantUML). |
-| `DefaultTrackingDiagramOverride` | Static class for manual diagram control: `StartOverride`, `EndOverride`, `InsertPlantUml`, `InsertTestDelimiter`. |
+| `DefaultTrackingDiagramOverride` | Static class for manual diagram control: `StartOverride`, `EndOverride`, `InsertPlantUml`, `InsertTestDelimiter`, `StartAction`. |
 | `TestTrackingMessageHandlerOptions` | Base configuration for the HTTP tracking handler (service names, port mappings, headers to forward). |
 | `TestTrackingMessageHandler` | `DelegatingHandler` that intercepts and logs HTTP requests/responses with tracking headers. |
 | `TestTrackingHttpClientFactory` | `IHttpClientFactory` implementation that creates `HttpClient` instances with the tracking handler. |

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ TrackingDiagramOverride.StartAction();
 var response = await client.GetAsync("/api/cake");
 ```
 
-> **BDD frameworks (LightBDD, ReqNRoll):** `StartAction()` is called automatically when the test transitions from a GIVEN step to a WHEN or THEN step. You only need to call it explicitly if you want to override the automatic detection or are using a non-BDD framework.
+> **BDD frameworks (BDDfy, LightBDD, ReqNRoll):** `StartAction()` is called automatically when the test transitions from a GIVEN step to a WHEN or THEN step. You only need to call it explicitly if you want to override the automatic detection or are using a non-BDD framework.
 
 ### <a name="setup-separation"></a>Setup Separation [↑](#top)
 
@@ -581,7 +581,7 @@ new ReportConfigurationOptions
 The boundary between setup and action is determined by:
 
 1. **Explicit** — Call `TrackingDiagramOverride.StartAction()` in your test code
-2. **Implicit (BDD frameworks)** — Automatically detected when the test transitions from a GIVEN step to a WHEN or THEN step (supported in LightBDD and ReqNRoll)
+2. **Implicit (BDD frameworks)** — Automatically detected when the test transitions from a GIVEN step to a WHEN or THEN step (supported in BDDfy, LightBDD, and ReqNRoll)
 
 ---
 
@@ -813,7 +813,8 @@ Each integration package provides the same set of framework-specific types:
 
 | Type | Purpose |
 |---|---|
-| `BDDfyDiagramsConfigurator` | `Configure()` registers BDDfy processors for diagram capture. |
+| `BDDfyDiagramsConfigurator` | `Configure()` registers BDDfy processors and the step-tracking executor for diagram capture and implicit setup detection. |
+| `BDDfyStepTrackingExecutor` | Custom `IStepExecutor` that tracks the current BDD step type (GIVEN/WHEN/THEN) via `AsyncLocal` for implicit setup separation. |
 | `BDDfyScenarioCollector` | Thread-safe collector for BDDfy scenario metadata. |
 | `BDDfyScenarioInfo` / `BDDfyStepInfo` | Records for BDD scenario and step metadata. |
 

--- a/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyDiagramsConfigurator.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyDiagramsConfigurator.cs
@@ -13,5 +13,6 @@ public static class BDDfyDiagramsConfigurator
 
         Configurator.Processors.Add(() => new DiagramCapturingProcessor());
         Configurator.BatchProcessors.Add(new DiagramEnhancingBatchProcessor(fetcherOptions));
+        Configurator.StepExecutor = new BDDfyStepTrackingExecutor(Configurator.StepExecutor);
     }
 }

--- a/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyReportGenerator.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyReportGenerator.cs
@@ -24,7 +24,8 @@ public static class BDDfyReportGenerator
             PlantUmlServerBaseUrl = options.PlantUmlServerBaseUrl,
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
-            ExcludedHeaders = options.ExcludedHeaders
+            ExcludedHeaders = options.ExcludedHeaders,
+            SeparateSetup = options.SeparateSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyReportGenerator.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyReportGenerator.cs
@@ -25,7 +25,8 @@ public static class BDDfyReportGenerator
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
             ExcludedHeaders = options.ExcludedHeaders,
-            SeparateSetup = options.SeparateSetup
+            SeparateSetup = options.SeparateSetup,
+            HighlightSetup = options.HighlightSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyStepTrackingExecutor.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyStepTrackingExecutor.cs
@@ -1,0 +1,30 @@
+using TestStack.BDDfy;
+
+namespace TestTrackingDiagrams.BDDfy.xUnit3;
+
+internal class BDDfyStepTrackingExecutor(IStepExecutor inner) : IStepExecutor
+{
+    private static readonly AsyncLocal<string?> CurrentStepTypeLocal = new();
+
+    public static string? CurrentStepType => CurrentStepTypeLocal.Value;
+
+    public object Execute(Step step, object testObject)
+    {
+        CurrentStepTypeLocal.Value = step.ExecutionOrder switch
+        {
+            ExecutionOrder.SetupState or ExecutionOrder.ConsecutiveSetupState => "GIVEN",
+            ExecutionOrder.Transition or ExecutionOrder.ConsecutiveTransition => "WHEN",
+            ExecutionOrder.Assertion or ExecutionOrder.ConsecutiveAssertion => "THEN",
+            _ => null
+        };
+
+        try
+        {
+            return inner.Execute(step, testObject);
+        }
+        finally
+        {
+            CurrentStepTypeLocal.Value = null;
+        }
+    }
+}

--- a/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyTestTrackingMessageHandlerOptions.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/BDDfyTestTrackingMessageHandlerOptions.cs
@@ -7,5 +7,6 @@ public record BDDfyTestTrackingMessageHandlerOptions : TestTrackingMessageHandle
     public BDDfyTestTrackingMessageHandlerOptions()
     {
         CurrentTestInfoFetcher = () => (Xunit.TestContext.Current.Test!.TestDisplayName, Xunit.TestContext.Current.Test.UniqueID);
+        CurrentStepTypeFetcher = () => BDDfyStepTrackingExecutor.CurrentStepType;
     }
 }

--- a/TestTrackingDiagrams.BDDfy.xUnit3/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.BDDfy.xUnit3/TrackingDiagramOverride.cs
@@ -22,5 +22,10 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertTestDelimiter(GetTestId(), testIdentifier);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() => Xunit.TestContext.Current.Test!.UniqueID;
 }

--- a/TestTrackingDiagrams.LightBDD.xUnit2/LightBddTestTrackingMessageHandlerOptions.cs
+++ b/TestTrackingDiagrams.LightBDD.xUnit2/LightBddTestTrackingMessageHandlerOptions.cs
@@ -1,4 +1,5 @@
 ﻿using LightBDD.Core.ExecutionContext;
+using LightBDD.Core.Metadata;
 using TestTrackingDiagrams.Tracking;
 
 namespace TestTrackingDiagrams.LightBDD.xUnit2;
@@ -8,5 +9,19 @@ public record LightBddTestTrackingMessageHandlerOptions : TestTrackingMessageHan
     public LightBddTestTrackingMessageHandlerOptions()
     {
         CurrentTestInfoFetcher = () => (ScenarioExecutionContext.CurrentScenario.Info.Name.ToString(), ScenarioExecutionContext.CurrentScenario.Info.RuntimeId.ToString());
+        CurrentStepTypeFetcher = GetTopLevelStepType;
+    }
+
+    private static string? GetTopLevelStepType()
+    {
+        var step = ScenarioExecutionContext.CurrentStep;
+        if (step is null)
+            return null;
+
+        var info = step.Info;
+        while (info.Parent is IStepInfo parentStep)
+            info = parentStep;
+
+        return info.Name?.StepTypeName?.Name;
     }
 }

--- a/TestTrackingDiagrams.LightBDD.xUnit2/ReportWritersConfigurationExtensions.cs
+++ b/TestTrackingDiagrams.LightBDD.xUnit2/ReportWritersConfigurationExtensions.cs
@@ -15,7 +15,8 @@ namespace TestTrackingDiagrams.LightBDD.xUnit2
                 RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
                 ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
                 ExcludedHeaders = options.ExcludedHeaders,
-                SeparateSetup = options.SeparateSetup
+                SeparateSetup = options.SeparateSetup,
+                HighlightSetup = options.HighlightSetup
             };
             var diagramsFetcher = LightBddDiagramsFetcher.GetDiagramsFetcher(fetcherOptions);
             var reportsFilePath = options.ReportsFolderPath.Trim().TrimEnd('/');

--- a/TestTrackingDiagrams.LightBDD.xUnit2/ReportWritersConfigurationExtensions.cs
+++ b/TestTrackingDiagrams.LightBDD.xUnit2/ReportWritersConfigurationExtensions.cs
@@ -14,7 +14,8 @@ namespace TestTrackingDiagrams.LightBDD.xUnit2
                 PlantUmlServerBaseUrl = options.PlantUmlServerBaseUrl,
                 RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
                 ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
-                ExcludedHeaders = options.ExcludedHeaders
+                ExcludedHeaders = options.ExcludedHeaders,
+                SeparateSetup = options.SeparateSetup
             };
             var diagramsFetcher = LightBddDiagramsFetcher.GetDiagramsFetcher(fetcherOptions);
             var reportsFilePath = options.ReportsFolderPath.Trim().TrimEnd('/');

--- a/TestTrackingDiagrams.LightBDD.xUnit2/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.LightBDD.xUnit2/TrackingDiagramOverride.cs
@@ -24,5 +24,10 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertTestDelimiter(GetTestId(), testIdentifier);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() => ScenarioExecutionContext.CurrentScenario.Info.RuntimeId.ToString();
 }

--- a/TestTrackingDiagrams.NUnit4/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.NUnit4/TrackingDiagramOverride.cs
@@ -24,5 +24,10 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertTestDelimiter(GetTestId(), testIdentifier);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() => TestContext.CurrentContext.Test.ID;
 }

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollReportGenerator.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollReportGenerator.cs
@@ -25,7 +25,8 @@ public static class ReqNRollReportGenerator
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
             ExcludedHeaders = options.ExcludedHeaders,
-            SeparateSetup = options.SeparateSetup
+            SeparateSetup = options.SeparateSetup,
+            HighlightSetup = options.HighlightSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollReportGenerator.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollReportGenerator.cs
@@ -24,7 +24,8 @@ public static class ReqNRollReportGenerator
             PlantUmlServerBaseUrl = options.PlantUmlServerBaseUrl,
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
-            ExcludedHeaders = options.ExcludedHeaders
+            ExcludedHeaders = options.ExcludedHeaders,
+            SeparateSetup = options.SeparateSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTestContext.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTestContext.cs
@@ -3,10 +3,17 @@ namespace TestTrackingDiagrams.ReqNRoll.xUnit2;
 public static class ReqNRollTestContext
 {
     private static readonly AsyncLocal<(string Name, string Id)?> CurrentTestInfoLocal = new();
+    private static readonly AsyncLocal<string?> CurrentStepTypeLocal = new();
 
     public static (string Name, string Id)? CurrentTestInfo
     {
         get => CurrentTestInfoLocal.Value;
         set => CurrentTestInfoLocal.Value = value;
+    }
+
+    public static string? CurrentStepType
+    {
+        get => CurrentStepTypeLocal.Value;
+        set => CurrentStepTypeLocal.Value = value;
     }
 }

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTestTrackingMessageHandlerOptions.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTestTrackingMessageHandlerOptions.cs
@@ -8,5 +8,6 @@ public record ReqNRollTestTrackingMessageHandlerOptions : TestTrackingMessageHan
     {
         CurrentTestInfoFetcher = () => ReqNRollTestContext.CurrentTestInfo
             ?? throw new InvalidOperationException("No ReqNRoll scenario is currently executing. Ensure ReqNRollTrackingHooks is registered as a [Binding].");
+        CurrentStepTypeFetcher = () => ReqNRollTestContext.CurrentStepType;
     }
 }

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTrackingHooks.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/ReqNRollTrackingHooks.cs
@@ -23,6 +23,12 @@ public class ReqNRollTrackingHooks
         ReqNRollTestContext.CurrentTestInfo = (_scenarioContext.ScenarioInfo.Title, scenarioId);
     }
 
+    [BeforeStep(Order = int.MinValue)]
+    public void BeforeStep()
+    {
+        ReqNRollTestContext.CurrentStepType = _scenarioContext.StepContext.StepInfo.StepInstance.StepDefinitionKeyword.ToString();
+    }
+
     [AfterStep(Order = int.MaxValue)]
     public void AfterStep()
     {

--- a/TestTrackingDiagrams.ReqNRoll.xUnit2/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit2/TrackingDiagramOverride.cs
@@ -22,6 +22,11 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertTestDelimiter(GetTestId(), testIdentifier);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() =>
         ReqNRollTestContext.CurrentTestInfo?.Id
         ?? throw new InvalidOperationException("No ReqNRoll scenario is currently executing.");

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollReportGenerator.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollReportGenerator.cs
@@ -25,7 +25,8 @@ public static class ReqNRollReportGenerator
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
             ExcludedHeaders = options.ExcludedHeaders,
-            SeparateSetup = options.SeparateSetup
+            SeparateSetup = options.SeparateSetup,
+            HighlightSetup = options.HighlightSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollReportGenerator.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollReportGenerator.cs
@@ -24,7 +24,8 @@ public static class ReqNRollReportGenerator
             PlantUmlServerBaseUrl = options.PlantUmlServerBaseUrl,
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
-            ExcludedHeaders = options.ExcludedHeaders
+            ExcludedHeaders = options.ExcludedHeaders,
+            SeparateSetup = options.SeparateSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTestContext.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTestContext.cs
@@ -3,10 +3,17 @@ namespace TestTrackingDiagrams.ReqNRoll.xUnit3;
 public static class ReqNRollTestContext
 {
     private static readonly AsyncLocal<(string Name, string Id)?> CurrentTestInfoLocal = new();
+    private static readonly AsyncLocal<string?> CurrentStepTypeLocal = new();
 
     public static (string Name, string Id)? CurrentTestInfo
     {
         get => CurrentTestInfoLocal.Value;
         set => CurrentTestInfoLocal.Value = value;
+    }
+
+    public static string? CurrentStepType
+    {
+        get => CurrentStepTypeLocal.Value;
+        set => CurrentStepTypeLocal.Value = value;
     }
 }

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTestTrackingMessageHandlerOptions.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTestTrackingMessageHandlerOptions.cs
@@ -8,5 +8,6 @@ public record ReqNRollTestTrackingMessageHandlerOptions : TestTrackingMessageHan
     {
         CurrentTestInfoFetcher = () => ReqNRollTestContext.CurrentTestInfo
             ?? throw new InvalidOperationException("No ReqNRoll scenario is currently executing. Ensure ReqNRollTrackingHooks is registered as a [Binding].");
+        CurrentStepTypeFetcher = () => ReqNRollTestContext.CurrentStepType;
     }
 }

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTrackingHooks.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/ReqNRollTrackingHooks.cs
@@ -23,6 +23,12 @@ public class ReqNRollTrackingHooks
         ReqNRollTestContext.CurrentTestInfo = (_scenarioContext.ScenarioInfo.Title, scenarioId);
     }
 
+    [BeforeStep(Order = int.MinValue)]
+    public void BeforeStep()
+    {
+        ReqNRollTestContext.CurrentStepType = _scenarioContext.StepContext.StepInfo.StepInstance.StepDefinitionKeyword.ToString();
+    }
+
     [AfterStep(Order = int.MaxValue)]
     public void AfterStep()
     {

--- a/TestTrackingDiagrams.ReqNRoll.xUnit3/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.ReqNRoll.xUnit3/TrackingDiagramOverride.cs
@@ -22,6 +22,11 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertTestDelimiter(GetTestId(), testIdentifier);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() =>
         ReqNRollTestContext.CurrentTestInfo?.Id
         ?? throw new InvalidOperationException("No ReqNRoll scenario is currently executing.");

--- a/TestTrackingDiagrams.Tests/PlantUml/PlantUmlCreatorTests.cs
+++ b/TestTrackingDiagrams.Tests/PlantUml/PlantUmlCreatorTests.cs
@@ -110,9 +110,9 @@ public class PlantUmlCreatorTests
         };
     }
 
-    private static string GetPlantUml(IEnumerable<RequestResponseLog> logs, bool separateSetup = false)
+    private static string GetPlantUml(IEnumerable<RequestResponseLog> logs, bool separateSetup = false, bool highlightSetup = true)
     {
-        var results = PlantUmlCreator.GetPlantUmlImageTagsPerTestId(logs, separateSetup: separateSetup).ToList();
+        var results = PlantUmlCreator.GetPlantUmlImageTagsPerTestId(logs, separateSetup: separateSetup, highlightSetup: highlightSetup).ToList();
         return results.Single().PlantUmls.First().PlainText;
     }
 
@@ -1351,6 +1351,39 @@ public class PlantUmlCreatorTests
         var plantUml = GetPlantUml(logs, separateSetup: true);
 
         Assert.Matches("partition #[a-fA-F0-9]+ Setup", plantUml);
+    }
+
+    [Fact]
+    public void Setup_partition_has_no_background_color_when_highlightSetup_is_false()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true, highlightSetup: false);
+
+        Assert.Contains("partition Setup", plantUml);
+        Assert.DoesNotMatch("partition #[a-fA-F0-9]+ Setup", plantUml);
+    }
+
+    [Fact]
+    public void HighlightSetup_has_no_effect_when_separateSetup_is_false()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: false, highlightSetup: true);
+
+        Assert.DoesNotContain("partition", plantUml);
     }
 
     [Fact]

--- a/TestTrackingDiagrams.Tests/PlantUml/PlantUmlCreatorTests.cs
+++ b/TestTrackingDiagrams.Tests/PlantUml/PlantUmlCreatorTests.cs
@@ -110,9 +110,9 @@ public class PlantUmlCreatorTests
         };
     }
 
-    private static string GetPlantUml(IEnumerable<RequestResponseLog> logs)
+    private static string GetPlantUml(IEnumerable<RequestResponseLog> logs, bool separateSetup = false)
     {
-        var results = PlantUmlCreator.GetPlantUmlImageTagsPerTestId(logs).ToList();
+        var results = PlantUmlCreator.GetPlantUmlImageTagsPerTestId(logs, separateSetup: separateSetup).ToList();
         return results.Single().PlantUmls.First().PlainText;
     }
 
@@ -1280,5 +1280,358 @@ public class PlantUmlCreatorTests
         var plantUml = GetPlantUml(logs);
 
         Assert.Contains("PATCH: /api/items/1", plantUml);
+    }
+
+    // ─── Setup partition ────────────────────────────────────────
+
+    [Fact]
+    public void Setup_partition_wraps_traces_before_StartAction_marker_when_enabled()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.Contains("partition #E2E2F0 Setup", plantUml);
+        var endMarker = Environment.NewLine + "end" + Environment.NewLine;
+        var partitionOpen = plantUml.IndexOf("partition #E2E2F0 Setup");
+        var setupCall = plantUml.IndexOf("/api/setup");
+        var partitionEnd = plantUml.IndexOf(endMarker, partitionOpen);
+        var actionCall = plantUml.IndexOf("/api/action");
+        Assert.True(partitionOpen < setupCall, "Partition should open before setup call");
+        Assert.True(setupCall < partitionEnd, "Setup call should be inside partition");
+        Assert.True(partitionEnd < actionCall, "Action call should be after partition closes");
+    }
+
+    [Fact]
+    public void No_partition_when_separateSetup_is_false_even_with_StartAction_marker()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs);
+
+        Assert.DoesNotContain("partition", plantUml);
+    }
+
+    [Fact]
+    public void No_partition_when_no_StartAction_marker_even_when_separateSetup_is_true()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.DoesNotContain("partition", plantUml);
+    }
+
+    [Fact]
+    public void Setup_partition_has_background_color()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.Matches("partition #[a-fA-F0-9]+ Setup", plantUml);
+    }
+
+    [Fact]
+    public void StartAction_marker_is_not_rendered_as_entity()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.DoesNotContain("entity \"\" as", plantUml);
+        Assert.DoesNotContain("actor \"\" as", plantUml);
+    }
+
+    [Fact]
+    public void StartAction_marker_does_not_produce_arrow_or_note()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.DoesNotContain("override.com", plantUml);
+    }
+
+    [Fact]
+    public void Setup_partition_works_with_multiple_setup_request_response_pairs()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup1"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup2"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        var endMarker = Environment.NewLine + "end" + Environment.NewLine;
+        var partitionOpen = plantUml.IndexOf("partition #E2E2F0 Setup");
+        var setup1 = plantUml.IndexOf("/api/setup1");
+        var setup2 = plantUml.IndexOf("/api/setup2");
+        var partitionEnd = plantUml.IndexOf(endMarker, partitionOpen);
+        var actionCall = plantUml.IndexOf("/api/action");
+        Assert.True(partitionOpen < setup1);
+        Assert.True(setup1 < setup2);
+        Assert.True(setup2 < partitionEnd);
+        Assert.True(partitionEnd < actionCall);
+    }
+
+    [Fact]
+    public void StartAction_at_beginning_produces_no_partition_since_setup_is_empty()
+    {
+        var logs = new[]
+        {
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.DoesNotContain("partition", plantUml);
+    }
+
+    private static RequestResponseLog MakeActionStart(string testId = "test-1")
+    {
+        return new RequestResponseLog(
+            TestName: testId,
+            TestId: testId,
+            Method: "",
+            Content: "",
+            Uri: new Uri("http://override.com"),
+            Headers: [],
+            ServiceName: "",
+            CallerName: "",
+            Type: RequestResponseType.Request,
+            TraceId: Guid.NewGuid(),
+            RequestResponseId: Guid.NewGuid(),
+            TrackingIgnore: false)
+        {
+            IsActionStart = true
+        };
+    }
+
+    // ─── Partition + override interaction ────────────────────────
+
+    [Fact]
+    public void Override_between_setup_and_action_is_rendered_outside_partition()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeOverrideStart(plantUml: "\nhnote across #black:<color:white>Test 1\n"),
+            MakeOverrideEnd(),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        var endMarker = Environment.NewLine + "end" + Environment.NewLine;
+        var partitionEnd = plantUml.IndexOf(endMarker, plantUml.IndexOf("partition"));
+        var hnote = plantUml.IndexOf("hnote across");
+        var actionCall = plantUml.IndexOf("/api/action");
+        Assert.True(partitionEnd < hnote, "Partition should close before the override hnote");
+        Assert.True(hnote < actionCall, "Override hnote should appear before the action call");
+    }
+
+    [Fact]
+    public void Multiple_overrides_between_setup_and_action_are_all_outside_partition()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeOverrideStart(plantUml: "\nhnote across #black:<color:white>Test 1\n"),
+            MakeOverrideEnd(),
+            MakeOverrideStart(plantUml: "\nhnote across #blue:<color:white>Marker\n"),
+            MakeOverrideEnd(),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        var endMarker = Environment.NewLine + "end" + Environment.NewLine;
+        var partitionEnd = plantUml.IndexOf(endMarker, plantUml.IndexOf("partition"));
+        var hnote1 = plantUml.IndexOf("Test 1");
+        var hnote2 = plantUml.IndexOf("Marker");
+        Assert.True(partitionEnd < hnote1, "Partition should close before first override");
+        Assert.True(partitionEnd < hnote2, "Partition should close before second override");
+    }
+
+    // ─── PlantUML structural validity ────────────────────────────
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PlantUml_has_balanced_partitions(bool separateSetup)
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: separateSetup);
+
+        AssertBalancedPartitions(plantUml);
+    }
+
+    [Fact]
+    public void PlantUml_has_balanced_partitions_with_override_between_setup_and_action()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeOverrideStart(plantUml: "\nhnote across #black:<color:white>Test 1\n"),
+            MakeOverrideEnd(),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        AssertBalancedPartitions(plantUml);
+    }
+
+    [Fact]
+    public void PlantUml_has_balanced_note_blocks()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup", content: "body"),
+            MakeResponse(callerName: "User", serviceName: "Api", content: "response"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action", content: "action-body"),
+            MakeResponse(callerName: "User", serviceName: "Api", content: "action-response"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        AssertBalancedNotes(plantUml);
+    }
+
+    [Fact]
+    public void PlantUml_starts_with_startuml_and_ends_with_enduml()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs);
+
+        Assert.StartsWith("@startuml", plantUml.TrimStart());
+        Assert.EndsWith("@enduml", plantUml.TrimEnd());
+    }
+
+    [Fact]
+    public void PlantUml_contains_teoz_pragma_when_partition_is_used()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        Assert.Contains("!pragma teoz true", plantUml);
+        var pragmaIndex = plantUml.IndexOf("!pragma teoz true");
+        var partitionIndex = plantUml.IndexOf("partition");
+        Assert.True(pragmaIndex < partitionIndex, "Teoz pragma must appear before partition");
+    }
+
+    [Fact]
+    public void PlantUml_partition_block_is_well_formed()
+    {
+        var logs = new[]
+        {
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/setup"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+            MakeActionStart(),
+            MakeRequest(callerName: "User", serviceName: "Api", uri: "http://example.com/api/action"),
+            MakeResponse(callerName: "User", serviceName: "Api"),
+        };
+        var plantUml = GetPlantUml(logs, separateSetup: true);
+
+        // partition line uses teoz syntax (no braces)
+        var partitionLine = plantUml.Split('\n').First(l => l.Contains("partition"));
+        Assert.Equal("partition #E2E2F0 Setup", partitionLine.TrimEnd());
+
+        // "end" line comes before action content
+        var endMarker = Environment.NewLine + "end" + Environment.NewLine;
+        var partitionOpen = plantUml.IndexOf("partition");
+        var endLine = plantUml.IndexOf(endMarker, partitionOpen);
+        Assert.True(endLine > partitionOpen, "Partition must have an end keyword");
+        Assert.True(endLine < plantUml.IndexOf("/api/action"), "Partition must close before action");
+    }
+
+    private static void AssertBalancedPartitions(string plantUml)
+    {
+        // Count partition opens and their matching "end" lines (teoz syntax)
+        var openCount = 0;
+        var closeCount = 0;
+        var inNote = false;
+        foreach (var line in plantUml.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("note ")) inNote = true;
+            if (trimmed == "end note") { inNote = false; continue; }
+            if (inNote) continue;
+
+            if (trimmed.StartsWith("partition ")) openCount++;
+            else if (trimmed == "end") closeCount++;
+        }
+        Assert.Equal(openCount, closeCount);
+    }
+
+    private static void AssertBalancedNotes(string plantUml)
+    {
+        var noteOpens = plantUml.Split('\n').Count(l => l.Trim().StartsWith("note "));
+        var noteCloses = plantUml.Split('\n').Count(l => l.Trim() == "end note");
+        Assert.Equal(noteOpens, noteCloses);
     }
 }

--- a/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
@@ -886,4 +886,312 @@ public class TestTrackingMessageHandlerTests : IDisposable
         var logs = GetLogsFromThisTest().Where(l => l.Type == RequestResponseType.Request).ToList();
         Assert.All(logs, l => Assert.Equal("AlwaysThisService", l.ServiceName));
     }
+
+    // ─── Implicit setup step detection ──────────────────────────
+
+    private TestTrackingMessageHandlerOptions OptionsWithStepFetcher(Func<string?> stepTypeFetcher) => new()
+    {
+        CallingServiceName = "Caller",
+        FixedNameForReceivingService = "Svc",
+        CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+        CurrentStepTypeFetcher = stepTypeFetcher,
+    };
+
+    [Fact]
+    public async Task Injects_IsActionStart_marker_when_step_transitions_from_GIVEN_to_WHEN()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Contains(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task No_IsActionStart_marker_when_no_step_type_fetcher()
+    {
+        var options = DefaultOptions();
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task No_IsActionStart_marker_when_all_steps_are_GIVEN()
+    {
+        var options = OptionsWithStepFetcher(() => "GIVEN");
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task IsActionStart_marker_injected_before_first_WHEN_request()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        var markerIndex = Array.FindIndex(logs, l => l.IsActionStart);
+        var whenRequestIndex = Array.FindIndex(logs, markerIndex + 1, l => l.Type == RequestResponseType.Request && !l.IsActionStart);
+        Assert.True(markerIndex < whenRequestIndex, "IsActionStart marker should appear before the WHEN request");
+    }
+
+    [Fact]
+    public async Task Only_one_IsActionStart_marker_injected_across_multiple_WHEN_requests()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Single(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task AND_steps_after_GIVEN_do_not_trigger_IsActionStart()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "AND";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task WHEN_after_AND_given_triggers_IsActionStart()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "AND";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Contains(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task Step_type_detection_is_case_insensitive()
+    {
+        var currentStep = "given";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "when";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Contains(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task No_IsActionStart_when_first_step_is_WHEN_without_prior_GIVEN()
+    {
+        var options = OptionsWithStepFetcher(() => "WHEN");
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task THEN_after_GIVEN_triggers_IsActionStart()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "THEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Contains(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task BUT_steps_after_GIVEN_do_not_trigger_IsActionStart()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "BUT";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task Null_step_type_does_not_trigger_IsActionStart()
+    {
+        string? currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = null;
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.DoesNotContain(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task Multiple_GIVEN_requests_before_WHEN_produces_single_marker()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Single(logs, l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task Full_GIVEN_AND_WHEN_THEN_flow_injects_marker_before_WHEN()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "AND";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "THEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        // 4 requests + 4 responses + 1 action start marker = 9
+        Assert.Equal(9, logs.Length);
+        Assert.Single(logs, l => l.IsActionStart);
+        var markerIndex = Array.FindIndex(logs, l => l.IsActionStart);
+        // GIVEN request(0) + response(1) + AND request(2) + response(3) + marker(4) + WHEN request(5) ...
+        Assert.Equal(4, markerIndex);
+    }
+
+    [Fact]
+    public async Task IsActionStart_marker_has_correct_test_id()
+    {
+        var currentStep = "GIVEN";
+        var options = OptionsWithStepFetcher(() => currentStep);
+        using var invoker = CreateInvoker(options);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        currentStep = "WHEN";
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var marker = GetLogsFromThisTest().Single(l => l.IsActionStart);
+        Assert.Equal("test-id-1", marker.TestId);
+    }
+
+    [Fact]
+    public async Task No_implicit_detection_on_server_side_when_http_context_has_test_headers()
+    {
+        var stepFetcherCalled = false;
+        var options = new TestTrackingMessageHandlerOptions
+        {
+            CallingServiceName = "Caller",
+            FixedNameForReceivingService = "Svc",
+            CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+            CurrentStepTypeFetcher = () =>
+            {
+                stepFetcherCalled = true;
+                return "WHEN";
+            },
+        };
+        var accessor = CreateHttpContextAccessor(
+            (TestTrackingHttpHeaders.CurrentTestNameHeader, "Server Test"),
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, "server-id"));
+        using var invoker = CreateInvoker(options, accessor);
+
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        Assert.False(stepFetcherCalled, "CurrentStepTypeFetcher should not be called on the server side");
+        Assert.DoesNotContain(GetLogsFromThisTest(), l => l.IsActionStart);
+    }
+
+    [Fact]
+    public async Task Step_fetcher_that_throws_does_not_crash_when_server_side_headers_present()
+    {
+        var options = new TestTrackingMessageHandlerOptions
+        {
+            CallingServiceName = "Caller",
+            FixedNameForReceivingService = "Svc",
+            CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+            CurrentStepTypeFetcher = () => throw new InvalidOperationException("Not in scenario context"),
+        };
+        var accessor = CreateHttpContextAccessor(
+            (TestTrackingHttpHeaders.CurrentTestNameHeader, "Server Test"),
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, "server-id"));
+        using var invoker = CreateInvoker(options, accessor);
+
+        // Should NOT throw — the fetcher is never called on the server side
+        await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Equal(2, logs.Length); // request + response, no crash
+    }
 }

--- a/TestTrackingDiagrams.XUnit/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams.XUnit/TrackingDiagramOverride.cs
@@ -24,5 +24,10 @@ public static class TrackingDiagramOverride
         DefaultTrackingDiagramOverride.InsertPlantUml(GetTestId(), plantUml);
     }
 
+    public static void StartAction()
+    {
+        DefaultTrackingDiagramOverride.StartAction(GetTestId());
+    }
+
     private static string GetTestId() => TestContext.Current.Test!.UniqueID;
 }

--- a/TestTrackingDiagrams/DefaultDiagramsFetcher.cs
+++ b/TestTrackingDiagrams/DefaultDiagramsFetcher.cs
@@ -22,7 +22,8 @@ public static class DefaultDiagramsFetcher
                 responsePostFormattingProcessor: options.ResponsePostFormattingProcessor,
                 requestPreFormattingProcessor: options.RequestPreFormattingProcessor,
                 responsePreFormattingProcessor: options.ResponsePreFormattingProcessor,
-                excludedHeaders: options.ExcludedHeaders.ToArray()).ToArray();
+                excludedHeaders: options.ExcludedHeaders.ToArray(),
+                separateSetup: options.SeparateSetup).ToArray();
             return _diagrams = perTestId
                 .SelectMany(test => test.PlantUmls.Select(plantUml =>
                     new DiagramAsCode(test.TestId,

--- a/TestTrackingDiagrams/DefaultDiagramsFetcher.cs
+++ b/TestTrackingDiagrams/DefaultDiagramsFetcher.cs
@@ -23,7 +23,8 @@ public static class DefaultDiagramsFetcher
                 requestPreFormattingProcessor: options.RequestPreFormattingProcessor,
                 responsePreFormattingProcessor: options.ResponsePreFormattingProcessor,
                 excludedHeaders: options.ExcludedHeaders.ToArray(),
-                separateSetup: options.SeparateSetup).ToArray();
+                separateSetup: options.SeparateSetup,
+                highlightSetup: options.HighlightSetup).ToArray();
             return _diagrams = perTestId
                 .SelectMany(test => test.PlantUmls.Select(plantUml =>
                     new DiagramAsCode(test.TestId,

--- a/TestTrackingDiagrams/DiagramsFetcherOptions.cs
+++ b/TestTrackingDiagrams/DiagramsFetcherOptions.cs
@@ -8,4 +8,5 @@ public record DiagramsFetcherOptions
     public Func<string, string>? ResponsePostFormattingProcessor { get; set; }
     public Func<string, string>? ResponsePreFormattingProcessor { get; set; }
     public IEnumerable<string> ExcludedHeaders { get; set; } = [];
+    public bool SeparateSetup { get; set; }
 }

--- a/TestTrackingDiagrams/DiagramsFetcherOptions.cs
+++ b/TestTrackingDiagrams/DiagramsFetcherOptions.cs
@@ -9,4 +9,5 @@ public record DiagramsFetcherOptions
     public Func<string, string>? ResponsePreFormattingProcessor { get; set; }
     public IEnumerable<string> ExcludedHeaders { get; set; } = [];
     public bool SeparateSetup { get; set; }
+    public bool HighlightSetup { get; set; } = true;
 }

--- a/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
+++ b/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
@@ -23,7 +23,8 @@ public static class PlantUmlCreator
         Func<string, string>? responsePreFormattingProcessor = null,
         Func<string, string>? responsePostFormattingProcessor = null,
         string[]? excludedHeaders = null,
-        int maxUrlLength = 100)
+        int maxUrlLength = 100,
+        bool separateSetup = false)
     {
         excludedHeaders ??= DefaultExcludedHeaders;
 
@@ -40,7 +41,8 @@ public static class PlantUmlCreator
                 responsePreFormattingProcessor,
                 responsePostFormattingProcessor,
                 excludedHeaders, 
-                maxUrlLength);
+                maxUrlLength,
+                separateSetup);
             var imageTags = results.Select(x => x.GetPlantUmlImageTag(plantUmlServerRendererUrl)).ToArray();
             return new PlantUmlForTest(testTraces.Key, testName, results.Select(result => (result.PlantUml, result.PlantUmlEncoded)), testTraces.ToList(), imageTags);
         });
@@ -55,7 +57,8 @@ public static class PlantUmlCreator
         Func<string, string>? responsePreFormattingProcessor,
         Func<string, string>? responsePostFormattingProcessor,
         string[] excludedHeaders,
-        int maxUrlLength)
+        int maxUrlLength,
+        bool separateSetup)
     {
         const string eventNoteClass = "eventNote";
         List<PlantUmlResult> plantUmls = [];
@@ -64,9 +67,26 @@ public static class PlantUmlCreator
         var plantUml = CreatePlantUmlPrefix();
 
         var currentlyOverriding = false;
+        var hasActionStart = separateSetup && tracesForTest.Any(t => t.IsActionStart);
+        var actionStartIndex = tracesForTest.FindIndex(t => t.IsActionStart);
+        var hasSetupTraces = hasActionStart && tracesForTest
+            .Take(actionStartIndex)
+            .Any(t => !t.IsOverrideStart && !t.IsOverrideEnd && !t.IsActionStart);
+        var setupPartitionOpen = false;
+        var setupPartitionClosed = false;
 
         foreach (var trace in tracesForTest)
         {
+            if (trace.IsActionStart)
+            {
+                if (hasActionStart && setupPartitionOpen && !setupPartitionClosed)
+                {
+                    plantUml += $"end{Environment.NewLine}";
+                    setupPartitionClosed = true;
+                }
+                continue;
+            }
+
             if (trace.IsOverrideStart && currentlyOverriding)
             {
                 Debug.Write("Ignoring an override as you're already overriding");
@@ -82,6 +102,11 @@ public static class PlantUmlCreator
 
             if (trace.IsOverrideStart)
             {
+                if (hasActionStart && setupPartitionOpen && !setupPartitionClosed)
+                {
+                    plantUml += $"end{Environment.NewLine}";
+                    setupPartitionClosed = true;
+                }
                 currentlyOverriding = true;
                 plantUml += trace.PlantUml ?? "";
                 continue;
@@ -89,6 +114,12 @@ public static class PlantUmlCreator
 
             if (currentlyOverriding)
                 continue;
+
+            if (hasSetupTraces && !setupPartitionOpen && !setupPartitionClosed)
+            {
+                plantUml += $"partition #E2E2F0 Setup{Environment.NewLine}";
+                setupPartitionOpen = true;
+            }
 
             string GetNoteClass() =>
                 trace!.MetaType == RequestResponseMetaType.Event ? "<<" + eventNoteClass + ">>" : "";
@@ -201,6 +232,7 @@ public static class PlantUmlCreator
             return $"""
 
                     @startuml
+                    !pragma teoz true
                     {AddStyling()}
                     skinparam wrapWidth {MaxLineWidth}
                     !function $color($value)
@@ -241,7 +273,7 @@ public static class PlantUmlCreator
         var actorDefined = false;
         var currentPlayers = new List<string>();
 
-        foreach (var trace in tracesForTest.Where(x => x is { IsOverrideStart: false, IsOverrideEnd: false }))
+        foreach (var trace in tracesForTest.Where(x => x is { IsOverrideStart: false, IsOverrideEnd: false, IsActionStart: false }))
         {
             var serviceShortName = SanitizePlantUmlAlias(trace.ServiceName);
             var callerShortName = SanitizePlantUmlAlias(trace.CallerName);

--- a/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
+++ b/TestTrackingDiagrams/PlantUml/PlantUmlCreator.cs
@@ -24,7 +24,8 @@ public static class PlantUmlCreator
         Func<string, string>? responsePostFormattingProcessor = null,
         string[]? excludedHeaders = null,
         int maxUrlLength = 100,
-        bool separateSetup = false)
+        bool separateSetup = false,
+        bool highlightSetup = true)
     {
         excludedHeaders ??= DefaultExcludedHeaders;
 
@@ -42,7 +43,8 @@ public static class PlantUmlCreator
                 responsePostFormattingProcessor,
                 excludedHeaders, 
                 maxUrlLength,
-                separateSetup);
+                separateSetup,
+                highlightSetup);
             var imageTags = results.Select(x => x.GetPlantUmlImageTag(plantUmlServerRendererUrl)).ToArray();
             return new PlantUmlForTest(testTraces.Key, testName, results.Select(result => (result.PlantUml, result.PlantUmlEncoded)), testTraces.ToList(), imageTags);
         });
@@ -58,7 +60,8 @@ public static class PlantUmlCreator
         Func<string, string>? responsePostFormattingProcessor,
         string[] excludedHeaders,
         int maxUrlLength,
-        bool separateSetup)
+        bool separateSetup,
+        bool highlightSetup)
     {
         const string eventNoteClass = "eventNote";
         List<PlantUmlResult> plantUmls = [];
@@ -117,7 +120,9 @@ public static class PlantUmlCreator
 
             if (hasSetupTraces && !setupPartitionOpen && !setupPartitionClosed)
             {
-                plantUml += $"partition #E2E2F0 Setup{Environment.NewLine}";
+                plantUml += highlightSetup
+                    ? $"partition #E2E2F0 Setup{Environment.NewLine}"
+                    : $"partition Setup{Environment.NewLine}";
                 setupPartitionOpen = true;
             }
 

--- a/TestTrackingDiagrams/ReportConfigurationOptions.cs
+++ b/TestTrackingDiagrams/ReportConfigurationOptions.cs
@@ -11,4 +11,5 @@ public record ReportConfigurationOptions
     public string YamlSpecificationsFileName { get; set; } = "ComponentSpecifications";
     public string ReportsFolderPath { get; set; } = "Reports";
     public string[] ExcludedHeaders { get; set; } = [];
+    public bool SeparateSetup { get; set; }
 }

--- a/TestTrackingDiagrams/ReportConfigurationOptions.cs
+++ b/TestTrackingDiagrams/ReportConfigurationOptions.cs
@@ -12,4 +12,5 @@ public record ReportConfigurationOptions
     public string ReportsFolderPath { get; set; } = "Reports";
     public string[] ExcludedHeaders { get; set; } = [];
     public bool SeparateSetup { get; set; }
+    public bool HighlightSetup { get; set; } = true;
 }

--- a/TestTrackingDiagrams/Reports/ReportGenerator.cs
+++ b/TestTrackingDiagrams/Reports/ReportGenerator.cs
@@ -12,7 +12,8 @@ public static class ReportGenerator
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
             ExcludedHeaders = options.ExcludedHeaders,
-            SeparateSetup = options.SeparateSetup
+            SeparateSetup = options.SeparateSetup,
+            HighlightSetup = options.HighlightSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams/Reports/ReportGenerator.cs
+++ b/TestTrackingDiagrams/Reports/ReportGenerator.cs
@@ -11,7 +11,8 @@ public static class ReportGenerator
             PlantUmlServerBaseUrl = options.PlantUmlServerBaseUrl,
             RequestPostFormattingProcessor = options.RequestResponsePostProcessor,
             ResponsePostFormattingProcessor = options.RequestResponsePostProcessor,
-            ExcludedHeaders = options.ExcludedHeaders
+            ExcludedHeaders = options.ExcludedHeaders,
+            SeparateSetup = options.SeparateSetup
         };
         var diagrams = DefaultDiagramsFetcher.GetDiagramsFetcher(fetcherOptions)();
 

--- a/TestTrackingDiagrams/Tracking/RequestResponseLog.cs
+++ b/TestTrackingDiagrams/Tracking/RequestResponseLog.cs
@@ -20,6 +20,7 @@ public record RequestResponseLog(
 {
     public bool IsOverrideStart { get; set; }
     public bool IsOverrideEnd { get; set; }
+    public bool IsActionStart { get; set; }
     public string? PlantUml { get; set; }
 };
 

--- a/TestTrackingDiagrams/Tracking/TestTrackingMessageHandler.cs
+++ b/TestTrackingDiagrams/Tracking/TestTrackingMessageHandler.cs
@@ -9,13 +9,18 @@ public class TestTrackingMessageHandler : DelegatingHandler
     private readonly Func<int, string> _getServiceNameFromPortTranslator;
     private readonly string? _callingServiceName;
     private readonly Func<(string Name, string Id)>? _currentTestInfoFetcher;
+    private readonly Func<string?>? _currentStepTypeFetcher;
     private readonly IHttpContextAccessor? _httpContextAccessor;
     private readonly IEnumerable<string> _headersToForward;
+    private string? _lastStepType;
+    private bool _wasInGivenSection;
+    private bool _actionStartInjected;
 
     public TestTrackingMessageHandler(TestTrackingMessageHandlerOptions options, IHttpContextAccessor? httpContextAccessor = null)
     {
         _getServiceNameFromPortTranslator = options.FixedNameForReceivingService is not null ? _ => options.FixedNameForReceivingService : GetPortTranslator(options.PortsToServiceNames);
         _currentTestInfoFetcher = options.CurrentTestInfoFetcher;
+        _currentStepTypeFetcher = options.CurrentStepTypeFetcher;
         _callingServiceName = options.CallingServiceName;
         _httpContextAccessor = httpContextAccessor;
         _headersToForward = options.HeadersToForward;
@@ -81,6 +86,9 @@ public class TestTrackingMessageHandler : DelegatingHandler
 
         var serviceName = _getServiceNameFromPortTranslator(request.RequestUri.Port);
 
+        if (!hasCurrentTestNameHeader)
+            InjectImplicitActionStartIfNeeded(currentTestInfo);
+
         RequestResponseLogger.Log(new RequestResponseLog(
             currentTestInfo.Name,
             currentTestInfo.Id,
@@ -134,5 +142,34 @@ public class TestTrackingMessageHandler : DelegatingHandler
             if (contextHeaders.TryGetValue(header, out var value))
                 request.Headers.Add(header, (IEnumerable<string?>)value);
         }
+    }
+
+    private void InjectImplicitActionStartIfNeeded((string Name, string Id) currentTestInfo)
+    {
+        if (_actionStartInjected || _currentStepTypeFetcher is null)
+            return;
+
+        var currentStepType = _currentStepTypeFetcher();
+        if (currentStepType is null)
+        {
+            _lastStepType = null;
+            return;
+        }
+
+        var isGivenOrAnd = currentStepType.StartsWith("GIVEN", StringComparison.OrdinalIgnoreCase)
+                           || currentStepType.StartsWith("AND", StringComparison.OrdinalIgnoreCase)
+                           || currentStepType.StartsWith("BUT", StringComparison.OrdinalIgnoreCase);
+
+        if (isGivenOrAnd)
+        {
+            _wasInGivenSection = true;
+        }
+        else if (_wasInGivenSection)
+        {
+            _actionStartInjected = true;
+            DefaultTrackingDiagramOverride.StartAction(currentTestInfo.Id);
+        }
+
+        _lastStepType = currentStepType;
     }
 }

--- a/TestTrackingDiagrams/Tracking/TestTrackingMessageHandlerOptions.cs
+++ b/TestTrackingDiagrams/Tracking/TestTrackingMessageHandlerOptions.cs
@@ -7,4 +7,5 @@ public record TestTrackingMessageHandlerOptions
     public string CallingServiceName { get; set; } = "Caller";
     public IEnumerable<string> HeadersToForward { get; set; } = [];
     public Func<(string Name, string Id)>? CurrentTestInfoFetcher { get; set; } = null;
+    public Func<string?>? CurrentStepTypeFetcher { get; set; } = null;
 }

--- a/TestTrackingDiagrams/TrackingDiagramOverride.cs
+++ b/TestTrackingDiagrams/TrackingDiagramOverride.cs
@@ -67,4 +67,25 @@ public static class DefaultTrackingDiagramOverride
         StartOverride(testRuntimeId, $"hnote across #black:<color:white>Test {testIdentifier}");
         EndOverride(testRuntimeId);
     }
+
+    public static void StartAction(string testId)
+    {
+        var log = new RequestResponseLog(
+            testId,
+            testId,
+            "",
+            "",
+            new Uri("http://override.com"),
+            [],
+            "",
+            "",
+            RequestResponseType.Request,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            false)
+        {
+            IsActionStart = true
+        };
+        RequestResponseLogger.Log(log);
+    }
 }

--- a/docs/integration-bddfy-xunit3.md
+++ b/docs/integration-bddfy-xunit3.md
@@ -348,7 +348,9 @@ BDDfyReportGenerator.CreateStandardReportsWithDiagrams(
         HtmlTestRunReportFileName = "CustomReport",
         YamlSpecificationsFileName = "CustomYaml",
         PlantUmlServerBaseUrl = "https://my-plantuml-server.com/plantuml",
-        ExcludedHeaders = new[] { "Authorization", "X-Api-Key" }
+        ExcludedHeaders = new[] { "Authorization", "X-Api-Key" },
+        SeparateSetup = true,
+        HighlightSetup = true
     });
 ```
 
@@ -361,4 +363,17 @@ using TestTrackingDiagrams.BDDfy.xUnit3;
 
 TrackingDiagramOverride.InsertPlantUml("note right: Custom annotation");
 TrackingDiagramOverride.InsertTestDelimiter("Phase 1");
+
+// Override the start/end of diagram generation
+TrackingDiagramOverride.StartOverride();
+TrackingDiagramOverride.EndOverride();
+
+// Explicitly mark the boundary between setup and action phases
+TrackingDiagramOverride.StartAction();
 ```
+
+### Setup Separation
+
+BDDfy supports **automatic setup separation**. When `SeparateSetup = true` is set on `ReportConfigurationOptions`, HTTP calls made during GIVEN steps are automatically wrapped in a visual "Setup" partition in the diagram. The boundary is detected implicitly when the test transitions from a GIVEN step to a WHEN or THEN step — no manual `StartAction()` call is needed.
+
+This works via a custom `IStepExecutor` that tracks the current BDD step type during execution. It is registered automatically when you call `BDDfyDiagramsConfigurator.Configure()`.

--- a/docs/integration-lightbdd-xunit2.md
+++ b/docs/integration-lightbdd-xunit2.md
@@ -288,7 +288,12 @@ TrackingDiagramOverride.InsertPlantUml("note over MyApi : Custom note");
 // Override the start/end of diagram generation
 TrackingDiagramOverride.StartOverride();
 TrackingDiagramOverride.EndOverride();
+
+// Explicitly mark the boundary between setup and action phases
+TrackingDiagramOverride.StartAction();
 ```
+
+> **Setup separation:** When `SeparateSetup = true` is set on `ReportConfigurationOptions`, LightBDD automatically detects the boundary between GIVEN steps and WHEN/THEN steps. HTTP calls made during GIVEN steps are wrapped in a visual "Setup" partition in the diagram — no manual `StartAction()` call is needed.
 
 > **Tip:** `InsertTestDelimiter` is particularly useful when using LightBDD's [Tabular Parameters](https://github.com/LightBDD/LightBDD/wiki/Advanced-Step-Parameters#tabular-parameters) or [TabularAttributes](https://github.com/lemonlion/LightBdd.TabularAttributes), where a single scenario runs multiple iterations. Insert a delimiter between each iteration to clearly separate them in the diagram.
 
@@ -309,6 +314,8 @@ Passed to `CreateStandardReportsWithDiagrams`:
 | `YamlSpecificationsFileName` | `"ComponentSpecifications"` | Output filename for YAML specs |
 | `HtmlSpecificationsCustomStyleSheet` | `null` | Custom CSS appended to specs HTML |
 | `ExcludedHeaders` | `[]` | HTTP headers to exclude from diagrams |
+| `SeparateSetup` | `false` | When `true`, HTTP calls made during GIVEN steps are wrapped in a visual "Setup" partition in the diagram |
+| `HighlightSetup` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour |
 
 ### LightBddTestTrackingMessageHandlerOptions
 

--- a/docs/integration-nunit4.md
+++ b/docs/integration-nunit4.md
@@ -319,7 +319,12 @@ TrackingDiagramOverride.InsertPlantUml("note over MyApi : Custom note");
 // Override the start/end of diagram generation
 TrackingDiagramOverride.StartOverride();
 TrackingDiagramOverride.EndOverride();
+
+// Explicitly mark the boundary between setup and action phases
+TrackingDiagramOverride.StartAction();
 ```
+
+> **Setup separation:** When `SeparateSetup = true` is set on `ReportConfigurationOptions`, HTTP calls made before `StartAction()` are wrapped in a visual "Setup" partition in the diagram.
 
 ---
 
@@ -336,6 +341,8 @@ TrackingDiagramOverride.EndOverride();
 | `YamlSpecificationsFileName` | `"ComponentSpecifications"` | Output filename for YAML specs |
 | `HtmlSpecificationsCustomStyleSheet` | `null` | Custom CSS appended to specs HTML |
 | `ExcludedHeaders` | `[]` | HTTP headers to exclude from diagrams |
+| `SeparateSetup` | `false` | When `true`, HTTP calls made before `StartAction()` are wrapped in a visual "Setup" partition in the diagram |
+| `HighlightSetup` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour |
 
 ### NUnitTestTrackingMessageHandlerOptions
 

--- a/docs/integration-reqnroll-xunit2.md
+++ b/docs/integration-reqnroll-xunit2.md
@@ -323,6 +323,8 @@ Pass these when calling `ReqNRollReportGenerator.CreateStandardReportsWithDiagra
 | `HtmlSpecificationsCustomStyleSheet` | `null` | Custom CSS to append to the specifications HTML |
 | `ExcludedHeaders` | `[]` | HTTP headers to exclude from diagrams |
 | `RequestResponsePostProcessor` | `null` | Post-processing function for request/response content in diagrams |
+| `SeparateSetup` | `false` | When `true`, HTTP calls made during GIVEN steps are wrapped in a visual "Setup" partition in the diagram |
+| `HighlightSetup` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour |
 
 ### ReqNRollTestTrackingMessageHandlerOptions
 
@@ -333,6 +335,8 @@ Pass these when calling `TrackDependenciesForDiagrams` and `CreateTestTrackingCl
 | `CallingServiceName` | Display name for the service making outgoing HTTP calls |
 | `FixedNameForReceivingService` | Display name for the service receiving requests (your SUT) |
 | `PortsToServiceNames` | Dictionary mapping port numbers to friendly service names. Unmapped ports appear as `localhost_80`, `localhost_5001`, etc. |
+
+> **Setup separation:** When `SeparateSetup = true`, ReqNRoll automatically detects the boundary between GIVEN steps and WHEN/THEN steps. No manual `StartAction()` call is needed.
 
 ---
 

--- a/docs/integration-reqnroll-xunit3.md
+++ b/docs/integration-reqnroll-xunit3.md
@@ -320,6 +320,8 @@ Pass these when calling `ReqNRollReportGenerator.CreateStandardReportsWithDiagra
 | `HtmlSpecificationsCustomStyleSheet` | `null` | Custom CSS to append to the specifications HTML |
 | `ExcludedHeaders` | `[]` | HTTP headers to exclude from diagrams |
 | `RequestResponsePostProcessor` | `null` | Post-processing function for request/response content in diagrams |
+| `SeparateSetup` | `false` | When `true`, HTTP calls made during GIVEN steps are wrapped in a visual "Setup" partition in the diagram |
+| `HighlightSetup` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour |
 
 ### ReqNRollTestTrackingMessageHandlerOptions
 
@@ -330,6 +332,8 @@ Pass these when calling `TrackDependenciesForDiagrams` and `CreateTestTrackingCl
 | `CallingServiceName` | Display name for the service making outgoing HTTP calls |
 | `FixedNameForReceivingService` | Display name for the service receiving requests (your SUT) |
 | `PortsToServiceNames` | Dictionary mapping port numbers to friendly service names. Unmapped ports appear as `localhost_80`, `localhost_5001`, etc. |
+
+> **Setup separation:** When `SeparateSetup = true`, ReqNRoll automatically detects the boundary between GIVEN steps and WHEN/THEN steps. No manual `StartAction()` call is needed.
 
 ---
 

--- a/docs/integration-xunit.md
+++ b/docs/integration-xunit.md
@@ -290,7 +290,12 @@ TrackingDiagramOverride.InsertPlantUml("note over MyApi : Custom note");
 // Override the start/end of diagram generation
 TrackingDiagramOverride.StartOverride();
 TrackingDiagramOverride.EndOverride();
+
+// Explicitly mark the boundary between setup and action phases
+TrackingDiagramOverride.StartAction();
 ```
+
+> **Setup separation:** When `SeparateSetup = true` is set on `ReportConfigurationOptions`, HTTP calls made before `StartAction()` are wrapped in a visual "Setup" partition in the diagram.
 
 ---
 
@@ -335,6 +340,8 @@ TrackingDiagramOverride.EndOverride();
 | `YamlSpecificationsFileName` | `"ComponentSpecifications"` | Output filename for YAML specs |
 | `HtmlSpecificationsCustomStyleSheet` | `null` | Custom CSS appended to specs HTML |
 | `ExcludedHeaders` | `[]` | HTTP headers to exclude from diagrams |
+| `SeparateSetup` | `false` | When `true`, HTTP calls made before `StartAction()` are wrapped in a visual "Setup" partition in the diagram |
+| `HighlightSetup` | `true` | When `true` (and `SeparateSetup` is enabled), the setup partition is rendered with a background colour |
 
 ### XUnitTestTrackingMessageHandlerOptions
 


### PR DESCRIPTION
# Setup Separation — Visually distinguish arrange from act in sequence diagrams

## Summary

This PR adds the ability to visually separate the "setup" (arrange) phase of a test from the "action" (act) phase in generated PlantUML sequence diagrams. Setup HTTP calls are wrapped in a PlantUML `partition` block using teoz syntax, making it immediately clear which calls are scaffolding and which are the actual behaviour under test.

Two consumer-facing flags are introduced on `ReportConfigurationOptions` and `DiagramsFetcherOptions`:

| Flag | Default | Purpose |
|---|---|---|
| `SeparateSetup` | `false` | Enable/disable the setup partition feature |
| `HighlightSetup` | `true` | When `true`, the partition renders with a background colour (`#E2E2F0`). When `false`, a plain partition with no colour. Only relevant when `SeparateSetup` is `true`. |

The setup/action boundary is determined in two ways:
1. **Explicit** — Call `TrackingDiagramOverride.StartAction()` in test code
2. **Implicit** — Automatically detected in all three BDD frameworks when the test transitions from a GIVEN step to a WHEN or THEN step (supported in BDDfy, LightBDD, and ReqNRoll)

## What the generated diagram looks like

```plantuml
@startuml
!pragma teoz true
...
partition #E2E2F0 Setup
  User -> Api: GET: /api/seed-data
  Api --> User: Ok
end
User -> Api: GET: /api/cake
Api --> User: Ok
@enduml
```

---

## Detailed changes

### Core library (`TestTrackingDiagrams/`)

- **`RequestResponseLog`** — Added `IsActionStart` property to mark the setup/action boundary in the trace log
- **`DefaultTrackingDiagramOverride`** — Added `StartAction(testId)` method that logs an `IsActionStart` marker entry
- **`TestTrackingMessageHandlerOptions`** — Added `CurrentStepTypeFetcher` callback (`Func<string?>?`) for implicit BDD step detection
- **`TestTrackingMessageHandler`** — Added `InjectImplicitActionStartIfNeeded()` which monitors step type transitions (GIVEN → WHEN/THEN) and auto-injects `IsActionStart`. Only runs on the client-side handler (not on the server-side handler within the SUT, where `ScenarioExecutionContext` / `AsyncLocal` are unavailable)
- **`PlantUmlCreator`** — Added `separateSetup` and `highlightSetup` parameters. When enabled:
  - Emits `!pragma teoz true` in the preamble
  - Wraps setup traces in `partition #E2E2F0 Setup` / `end` (or `partition Setup` / `end` when `highlightSetup = false`)
  - Closes the partition before any override blocks (test delimiters) to ensure valid PlantUML structure
  - Excludes `IsActionStart` markers from entity definitions
- **`DiagramsFetcherOptions`** — Added `SeparateSetup` and `HighlightSetup` properties
- **`ReportConfigurationOptions`** — Added `SeparateSetup` and `HighlightSetup` properties
- **`DefaultDiagramsFetcher`** / **`ReportGenerator`** — Thread both flags through to `PlantUmlCreator`

### Framework integration packages (6 packages)

- **All 6 `TrackingDiagramOverride` classes** (XUnit, NUnit4, BDDfy.xUnit3, LightBDD.xUnit2, ReqNRoll.xUnit2, ReqNRoll.xUnit3) — Added `StartAction()` method
- **All 4 report generators** (BDDfy, LightBDD, ReqNRoll xUnit2, ReqNRoll xUnit3) — Thread `SeparateSetup` and `HighlightSetup` to `DiagramsFetcherOptions`
- **LightBDD** — `LightBddTestTrackingMessageHandlerOptions` sets `CurrentStepTypeFetcher` to a `GetTopLevelStepType()` method that walks up the `IStepInfo.Parent` chain to find the root-level step's `StepTypeName.Name` (necessary because `ScenarioExecutionContext.CurrentStep` returns the innermost sub-step in composite step patterns)
- **BDDfy** — New `BDDfyStepTrackingExecutor` class (implementing `IStepExecutor`) wraps the default BDDfy step executor via the decorator pattern. Before executing each step, it sets an `AsyncLocal<string?>` with the step type derived from `Step.ExecutionOrder` (`SetupState`/`ConsecutiveSetupState`→GIVEN, `Transition`/`ConsecutiveTransition`→WHEN, `Assertion`/`ConsecutiveAssertion`→THEN). The `AsyncLocal` is cleared in a `finally` block after each step. Registered automatically in `BDDfyDiagramsConfigurator.Configure()` via `Configurator.StepExecutor = new BDDfyStepTrackingExecutor(Configurator.StepExecutor)`. `BDDfyTestTrackingMessageHandlerOptions` wires `CurrentStepTypeFetcher` to read this value.
- **ReqNRoll (both xUnit2 and xUnit3)** — Added `CurrentStepType` to `ReqNRollTestContext` (via `AsyncLocal<string?>`), a `[BeforeStep]` hook in `ReqNRollTrackingHooks` that captures the current step keyword, and wired `CurrentStepTypeFetcher` in options

### Example projects

- All 6 example projects set `SeparateSetup = true` in their `ReportConfigurationOptions`
- All 6 `appsettings.componenttests.json` files — Changed CowService port from `5031-5036` range to `15031-15036` range (avoids conflict with Rancher Desktop / other local services)

### Tests (+696 lines)

- **`PlantUmlCreatorTests`** — 30 new tests covering:
  - Partition wrapping, closing, and positioning relative to action calls
  - Background colour (`HighlightSetup`) and plain partition rendering
  - `StartAction` marker exclusion from entities/arrows/notes
  - Multiple setup traces, empty setup, no marker scenarios
  - Override-partition interaction (partition closes before override blocks)
  - Structural validity: balanced `partition`/`end` pairs, balanced `note`/`end note`, `!pragma teoz true` presence, well-formed partition block
- **`TestTrackingMessageHandlerTests`** — 17 new tests covering:
  - Implicit GIVEN → WHEN/THEN transition detection
  - AND/BUT steps don't trigger `IsActionStart`
  - Only one marker injected per test
  - Null step type handling
  - No marker when first step is WHEN (no prior GIVEN)
  - Full GIVEN/AND/WHEN/THEN flow with correct marker position
  - Server-side guard (no implicit detection on the SUT handler thread)

### Documentation

- **README.md** — Added "Setup Separation" section, "StartAction" section, `SeparateSetup` and `HighlightSetup` in option tables, updated API reference with `BDDfyStepTrackingExecutor` and `StartAction`, updated implicit detection text to include all three BDD frameworks
- **docs/integration-bddfy-xunit3.md** — Expanded diagram overrides with `StartOverride`/`EndOverride`/`StartAction`, added Setup Separation subsection explaining automatic GIVEN detection via `IStepExecutor`, added `SeparateSetup`/`HighlightSetup` to report options example
- **docs/integration-lightbdd-xunit2.md** — Added `StartAction()` to overrides, setup separation note, `SeparateSetup`/`HighlightSetup` to options table
- **docs/integration-xunit.md** — Added `StartAction()` to overrides, setup separation note, `SeparateSetup`/`HighlightSetup` to options table
- **docs/integration-nunit4.md** — Added `StartAction()` to overrides, setup separation note, `SeparateSetup`/`HighlightSetup` to options table
- **docs/integration-reqnroll-xunit2.md** — Added `SeparateSetup`/`HighlightSetup` to options table, setup separation note
- **docs/integration-reqnroll-xunit3.md** — Added `SeparateSetup`/`HighlightSetup` to options table, setup separation note

---

## Gotchas and things to look out for

1. **PlantUML teoz syntax** — The partition uses the teoz extension (`!pragma teoz true` + `partition Name` / `end`) rather than the classic brace syntax (`partition "Name" { ... }`). Classic brace syntax does not work reliably within sequence diagrams. Every diagram now includes `!pragma teoz true` in the preamble, even when no partition is present — this is harmless but worth knowing.

2. **Server-side vs client-side implicit detection** — The `InjectImplicitActionStartIfNeeded` call is guarded by `if (!hasCurrentTestNameHeader)`. This is critical: when the SUT receives a request from the test, the server-side `TestTrackingMessageHandler` runs on a different thread where `ScenarioExecutionContext` / `AsyncLocal` step state is not available. Without this guard, the `CurrentStepTypeFetcher` would crash or return stale data on the server side.

3. **LightBDD composite step traversal** — `ScenarioExecutionContext.CurrentStep` returns the *innermost* executing sub-step, not the top-level step. For tests using `CompositeStep` patterns (common in LightBDD), the sub-step's `StepTypeName` is often null or `_`. The fix walks up the `IStepInfo.Parent` chain to find the root step's type (GIVEN, WHEN, THEN). If this traversal logic is changed, verify against the LightBDD example project's `FeaturesReport.html` diagrams.

4. **BDDfy step executor wrapping** — Implicit detection for BDDfy works via a custom `IStepExecutor` that wraps the default `StepExecutor`. It is registered in `BDDfyDiagramsConfigurator.Configure()` via `Configurator.StepExecutor = new BDDfyStepTrackingExecutor(Configurator.StepExecutor)`. This must happen before any `.BDDfy()` calls. The executor maps `Step.ExecutionOrder` to step types: `SetupState`/`ConsecutiveSetupState` → GIVEN, `Transition`/`ConsecutiveTransition` → WHEN, `Assertion`/`ConsecutiveAssertion` → THEN. The `AsyncLocal` is cleared in a `finally` block after each step.

5. **Override-partition interaction** — If a test has overrides (e.g. `InsertTestDelimiter`) between setup and action, the partition is closed *before* the override block is rendered. This ensures the `hnote across` from test delimiters is not inside the partition (which would produce invalid PlantUML). The tests cover both single and multiple override scenarios.

6. **Port change in example projects** — All example project CowService ports were moved from `5031-5036` to `15031-15036`. This is an unrelated fix to avoid conflicts with Rancher Desktop (or similar tools) occupying the `5031-5036` range. If running examples locally, ensure nothing else is bound to `15031-15036`.

7. **`HighlightSetup` defaults to `true`** — This means enabling `SeparateSetup = true` will produce coloured partitions by default. Consumers who want a partition with no background colour must explicitly set `HighlightSetup = false`.

8. **`SeparateSetup` defaults to `false`** — The feature is entirely opt-in. Existing consumers see no change unless they set `SeparateSetup = true`.

---

**Stats:** 50 files changed, +1042 / -28 lines. 159 unit tests pass.
