### PR TITLE
Add MessageTracker for non-HTTP interaction tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: write  # Required to create GitHub Releases
 

--- a/Example.Api/src/Example.Api/Controllers/CakeController.cs
+++ b/Example.Api/src/Example.Api/Controllers/CakeController.cs
@@ -1,3 +1,4 @@
+using Example.Api.Events;
 using Example.Api.Requests;
 using Example.Api.Responses;
 using Microsoft.AspNetCore.Mvc;
@@ -6,11 +7,15 @@ namespace Example.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class CakeController : ControllerBase
+public class CakeController(IEventPublisher eventPublisher) : ControllerBase
 {
     [HttpPost]
-    public CakeResponse MakeCake(CakeRequest request)
+    public async Task<CakeResponse> MakeCake(CakeRequest request)
     {
-        return new CakeResponse { Ingredients = new [] { request.Eggs!, request.Milk!, request.Flour! } };
+        var response = new CakeResponse { Ingredients = new [] { request.Eggs!, request.Milk!, request.Flour! } };
+
+        await eventPublisher.PublishAsync(new CakeCreatedEvent(response.BatchId, response.Ingredients));
+
+        return response;
     }
 }

--- a/Example.Api/src/Example.Api/Events/CakeCreatedEvent.cs
+++ b/Example.Api/src/Example.Api/Events/CakeCreatedEvent.cs
@@ -1,0 +1,3 @@
+namespace Example.Api.Events;
+
+public record CakeCreatedEvent(Guid BatchId, string[] Ingredients);

--- a/Example.Api/src/Example.Api/Events/IEventPublisher.cs
+++ b/Example.Api/src/Example.Api/Events/IEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace Example.Api.Events;
+
+public interface IEventPublisher
+{
+    Task PublishAsync(CakeCreatedEvent @event);
+}

--- a/Example.Api/src/Example.Api/Events/NoOpEventPublisher.cs
+++ b/Example.Api/src/Example.Api/Events/NoOpEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace Example.Api.Events;
+
+public class NoOpEventPublisher : IEventPublisher
+{
+    public Task PublishAsync(CakeCreatedEvent @event) => Task.CompletedTask;
+}

--- a/Example.Api/src/Example.Api/Program.cs
+++ b/Example.Api/src/Example.Api/Program.cs
@@ -1,3 +1,5 @@
+using Example.Api.Events;
+
 namespace Example.Api;
 
 public class Program
@@ -10,6 +12,7 @@ public class Program
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
         builder.Services.AddHttpClient();
+        builder.Services.AddSingleton<IEventPublisher, NoOpEventPublisher>();
 
         var app = builder.Build();
 

--- a/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
@@ -46,10 +46,7 @@ public class BDDfyTestSetup : IAsyncLifetime
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.BDDfy.xUnit3/Infrastructure/BDDfyTestSetup.cs
@@ -1,10 +1,14 @@
+using Example.Api.Events;
 using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using Example.Api.Tests.Component.Shared.HttpFakes;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using TestTrackingDiagrams;
 using TestTrackingDiagrams.BDDfy.xUnit3;
+using TestTrackingDiagrams.Tracking;
 using Xunit;
 using CowServiceHttpFake = Example.Api.HttpFakes.CowService.Program;
 
@@ -42,6 +46,11 @@ public class BDDfyTestSetup : IAsyncLifetime
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
 

--- a/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/BaseFixture.cs
@@ -1,9 +1,13 @@
+using Example.Api.Events;
 using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using LightBDD.XUnit2;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using TestTrackingDiagrams.LightBDD.xUnit2;
+using TestTrackingDiagrams.Tracking;
 
 namespace Example.Api.Tests.Component.LightBDD.xUnit2.Infrastructure;
 
@@ -29,6 +33,11 @@ public abstract class BaseFixture : FeatureFixture, IDisposable
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.LightBDD.xUnit2/Infrastructure/BaseFixture.cs
@@ -33,10 +33,7 @@ public abstract class BaseFixture : FeatureFixture, IDisposable
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/BaseFixture.cs
@@ -32,10 +32,7 @@ public abstract class BaseFixture : DiagrammedComponentTest, IDisposable
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.NUnit4/Infrastructure/BaseFixture.cs
@@ -1,7 +1,11 @@
+using Example.Api.Events;
 using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TestTrackingDiagrams.Tracking;
 using TestTrackingDiagrams.NUnit4;
 
 namespace Example.Api.Tests.Component.NUnit4.Infrastructure;
@@ -28,6 +32,11 @@ public abstract class BaseFixture : DiagrammedComponentTest, IDisposable
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
@@ -1,12 +1,16 @@
+using Example.Api.Events;
 using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using Example.Api.Tests.Component.Shared.HttpFakes;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Reqnroll;
 using Reqnroll.BoDi;
 using TestTrackingDiagrams;
 using TestTrackingDiagrams.ReqNRoll.xUnit2;
+using TestTrackingDiagrams.Tracking;
 using CowServiceHttpFake = Example.Api.HttpFakes.CowService.Program;
 
 namespace Example.Api.Tests.Component.ReqNRoll.xUnit2.Hooks;
@@ -37,6 +41,11 @@ public class TestSetupHooks
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit2/Hooks/TestSetupHooks.cs
@@ -41,10 +41,7 @@ public class TestSetupHooks
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
@@ -1,12 +1,16 @@
+using Example.Api.Events;
 using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using Example.Api.Tests.Component.Shared.HttpFakes;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Reqnroll;
 using Reqnroll.BoDi;
 using TestTrackingDiagrams;
 using TestTrackingDiagrams.ReqNRoll.xUnit3;
+using TestTrackingDiagrams.Tracking;
 using CowServiceHttpFake = Example.Api.HttpFakes.CowService.Program;
 
 namespace Example.Api.Tests.Component.ReqNRoll.xUnit3.Hooks;
@@ -37,6 +41,11 @@ public class TestSetupHooks
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.ReqNRoll.xUnit3/Hooks/TestSetupHooks.cs
@@ -41,10 +41,7 @@ public class TestSetupHooks
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(_settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/Example.Api/tests/Example.Api.Tests.Component.Shared/Example.Api.Tests.Component.Shared.csproj
+++ b/Example.Api/tests/Example.Api.Tests.Component.Shared/Example.Api.Tests.Component.Shared.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\fakes\Example.Api.HttpFakes.CowService\Example.Api.HttpFakes.CowService.csproj" />
     <ProjectReference Include="..\..\src\Example.Api\Example.Api.csproj" />
+    <ProjectReference Include="..\..\..\TestTrackingDiagrams\TestTrackingDiagrams.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
@@ -1,0 +1,24 @@
+using Example.Api.Events;
+using TestTrackingDiagrams.Tracking;
+
+namespace Example.Api.Tests.Component.Shared.Fakes;
+
+public class FakeEventPublisher(MessageTracker tracker) : IEventPublisher
+{
+    public Task PublishAsync(CakeCreatedEvent @event)
+    {
+        var correlationId = tracker.LogRequest(
+            protocol: "Event",
+            destinationName: "Cake Events",
+            destinationUri: new Uri("event://cake-created"),
+            payload: @event);
+
+        tracker.LogResponse(
+            protocol: "Event",
+            destinationName: "Cake Events",
+            destinationUri: new Uri("event://cake-created"),
+            requestResponseId: correlationId);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
@@ -7,13 +7,13 @@ public class FakeEventPublisher(MessageTracker tracker) : IEventPublisher
 {
     public Task PublishAsync(CakeCreatedEvent @event)
     {
-        var correlationId = tracker.LogRequest(
+        var correlationId = tracker.TrackMessageRequest(
             protocol: "Event",
             destinationName: "Cake Events",
             destinationUri: new Uri("event://cake-created"),
             payload: @event);
 
-        tracker.LogResponse(
+        tracker.TrackMessageResponse(
             protocol: "Event",
             destinationName: "Cake Events",
             destinationUri: new Uri("event://cake-created"),

--- a/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.Shared/Fakes/FakeEventPublisher.cs
@@ -9,13 +9,13 @@ public class FakeEventPublisher(MessageTracker tracker) : IEventPublisher
     {
         var correlationId = tracker.TrackMessageRequest(
             protocol: "Event",
-            destinationName: "Cake Events",
+            destinationName: "Event broker",
             destinationUri: new Uri("event://cake-created"),
             payload: @event);
 
         tracker.TrackMessageResponse(
             protocol: "Event",
-            destinationName: "Cake Events",
+            destinationName: "Event broker",
             destinationUri: new Uri("event://cake-created"),
             requestResponseId: correlationId);
 

--- a/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/BaseFixture.cs
@@ -1,7 +1,11 @@
-﻿using Example.Api.Tests.Component.Shared;
+﻿using Example.Api.Events;
+using Example.Api.Tests.Component.Shared;
+using Example.Api.Tests.Component.Shared.Fakes;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TestTrackingDiagrams.Tracking;
 using TestTrackingDiagrams.XUnit;
 
 namespace Example.Api.Tests.Component.XUnit.Infrastructure;
@@ -28,6 +32,11 @@ public abstract class BaseFixture : DiagrammedComponentTest
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
+                services.AddHttpContextAccessor();
+                services.AddSingleton(sp => new MessageTracker(
+                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
+                    ServiceUnderTestName));
+                services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });
     }

--- a/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/BaseFixture.cs
+++ b/Example.Api/tests/Example.Api.Tests.Component.XUnit/Infrastructure/BaseFixture.cs
@@ -32,10 +32,7 @@ public abstract class BaseFixture : DiagrammedComponentTest
                     CallingServiceName = ServiceUnderTestName,
                     PortsToServiceNames = { { new Uri(Settings.CowServiceBaseUrl!).Port, "Cow Service" } }
                 });
-                services.AddHttpContextAccessor();
-                services.AddSingleton(sp => new MessageTracker(
-                    sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-                    ServiceUnderTestName));
+                services.TrackMessagesForDiagrams(ServiceUnderTestName);
                 services.AddSingleton<IEventPublisher, FakeEventPublisher>();
             });
         });

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Each test that makes HTTP calls through the tracked pipeline automatically produ
 │  (Caller)   │ ◄──────────   │  (Your API) │ ◄──────────   │  (Fakes)    │
 └─────────────┘               └─────────────┘               └─────────────┘
        │                             │                             │
-       └───────────── All HTTP traffic is intercepted ─────────────┘
+       │                             │   Event / Message           │
+       │                             │ ─────────────────►  ┌──────┴──────┐
+       │                             │                     │Event broker │
+       │                             │                     │  (Fakes)    │
+       │                             │                     └──────┬──────┘
+       │                             │                             │
+       └───── All HTTP traffic + events/messages are intercepted ──┘
                                      │
                                      ▼
                           ┌─────────────────────┐
@@ -57,9 +63,9 @@ Each test that makes HTTP calls through the tracked pipeline automatically produ
                           └─────────────────────┘
 ```
 
-1. **Intercept** — A `TestTrackingMessageHandler` (a `DelegatingHandler`) is inserted into the HTTP pipeline. It logs every request and response, enriching them with tracking headers (test name, test ID, trace ID, caller name).
+1. **Intercept** — A `TestTrackingMessageHandler` (a `DelegatingHandler`) is inserted into the HTTP pipeline. It logs every request and response, enriching them with tracking headers (test name, test ID, trace ID, caller name). For non-HTTP interactions (events, messages, commands), `MessageTracker` logs them directly to the same in-memory store.
 
-2. **Collect** — All logged `RequestResponseLog` entries are held in the static `RequestResponseLogger`. Each entry captures the method, URI, headers, body, status code, service names, and a trace ID to correlate requests across services.
+2. **Collect** — All logged `RequestResponseLog` entries are held in the static `RequestResponseLogger`. Each entry captures the method, URI, headers, body, status code, service names, and a trace ID to correlate requests across services. Events and messages are stored alongside HTTP logs with a distinct `Event` meta type.
 
 3. **Generate** — At the end of the test run, `PlantUmlCreator` groups logs by test ID and converts them into PlantUML sequence diagram code. The code is encoded and rendered via a PlantUML server.
 

--- a/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
@@ -4,14 +4,13 @@ using TestTrackingDiagrams.Tracking;
 
 namespace TestTrackingDiagrams.Tests.Tracking;
 
-[Collection("RequestResponseLogger")]
 public class MessageTrackerTests
 {
-    private static int LogCount => RequestResponseLogger.RequestAndResponseLogs.Length;
-
-    private static RequestResponseLog[] GetLogsSince(int baseline)
+    private static RequestResponseLog[] GetLogsById(Guid requestResponseId)
     {
-        return RequestResponseLogger.RequestAndResponseLogs.Skip(baseline).ToArray();
+        return RequestResponseLogger.RequestAndResponseLogs
+            .Where(l => l.RequestResponseId == requestResponseId)
+            .ToArray();
     }
 
     private static IHttpContextAccessor CreateHttpContextAccessor(
@@ -40,11 +39,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_logs_a_request_entry()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
 
-        var logs = GetLogsSince(baseline);
+        var logs = GetLogsById(id);
         Assert.Single(logs);
         Assert.Equal(RequestResponseType.Request, logs[0].Type);
     }
@@ -63,11 +61,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_protocol_as_method()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
+        var id = tracker.TrackMessageRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal("EventGrid", log.Method.Value);
     }
 
@@ -75,11 +72,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_destination_as_service_name()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal("OrderService", log.ServiceName);
     }
 
@@ -87,11 +83,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_calling_service_name()
     {
         var tracker = CreateTracker(callingServiceName: "PublisherApp");
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal("PublisherApp", log.CallerName);
     }
 
@@ -99,11 +94,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_serialises_payload_as_content()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Contains("Widget", log.Content);
     }
 
@@ -112,11 +106,10 @@ public class MessageTrackerTests
     {
         var uri = new Uri("kafka://my-topic");
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", uri, new { });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", uri, new { });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal(uri, log.Uri);
     }
 
@@ -124,11 +117,10 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal(RequestResponseMetaType.Event, log.MetaType);
     }
 
@@ -137,11 +129,10 @@ public class MessageTrackerTests
     {
         var accessor = CreateHttpContextAccessor("SpecificTest", "id-42", "7c9e6679-7425-40de-944b-e07fc1f90ae7");
         var tracker = CreateTracker(accessor);
-        var baseline = LogCount;
 
-        tracker.TrackMessageRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
+        var id = tracker.TrackMessageRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
 
-        var log = GetLogsSince(baseline).Single();
+        var log = GetLogsById(id).Single();
         Assert.Equal("SpecificTest", log.TestName);
         Assert.Equal("id-42", log.TestId);
         Assert.Equal(Guid.Parse("7c9e6679-7425-40de-944b-e07fc1f90ae7"), log.TraceId);
@@ -153,12 +144,11 @@ public class MessageTrackerTests
     public void TrackMessageResponse_logs_a_response_entry()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
         var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
-        var logs = GetLogsSince(baseline);
+        var logs = GetLogsById(correlationId);
         Assert.Equal(2, logs.Length);
         Assert.Equal(RequestResponseType.Response, logs[1].Type);
     }
@@ -167,12 +157,11 @@ public class MessageTrackerTests
     public void TrackMessageResponse_uses_same_correlation_id_as_request()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
         var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
-        var logs = GetLogsSince(baseline);
+        var logs = GetLogsById(correlationId);
         Assert.Equal(logs[0].RequestResponseId, logs[1].RequestResponseId);
     }
 
@@ -180,12 +169,11 @@ public class MessageTrackerTests
     public void TrackMessageResponse_serialises_response_payload_when_provided()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
         tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id, new { Ack = true });
 
-        var responseLog = GetLogsSince(baseline).Last();
+        var responseLog = GetLogsById(id).Last();
         Assert.Contains("true", responseLog.Content);
     }
 
@@ -193,12 +181,11 @@ public class MessageTrackerTests
     public void TrackMessageResponse_sets_empty_content_when_no_response_payload()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
         tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id);
 
-        var responseLog = GetLogsSince(baseline).Last();
+        var responseLog = GetLogsById(id).Last();
         Assert.Equal(string.Empty, responseLog.Content);
     }
 
@@ -206,12 +193,11 @@ public class MessageTrackerTests
     public void TrackMessageResponse_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
-        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("Kafka", "Svc", new Uri("kafka://t"), new { });
 
         tracker.TrackMessageResponse("Kafka", "Svc", new Uri("kafka://t"), id);
 
-        var responseLog = GetLogsSince(baseline).Last();
+        var responseLog = GetLogsById(id).Last();
         Assert.Equal(RequestResponseMetaType.Event, responseLog.MetaType);
     }
 }

--- a/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
@@ -33,14 +33,14 @@ public class MessageTrackerTests
         return new MessageTracker(accessor ?? CreateHttpContextAccessor(), callingServiceName);
     }
 
-    // ─── LogRequest ─────────────────────────────────────────────
+    // ─── TrackMessageRequest ────────────────────────────────────
 
     [Fact]
-    public void LogRequest_logs_a_request_entry()
+    public void TrackMessageRequest_logs_a_request_entry()
     {
         var tracker = CreateTracker();
 
-        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
+        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
 
         var logs = GetLogsFromThisTest();
         Assert.Single(logs);
@@ -48,89 +48,89 @@ public class MessageTrackerTests
     }
 
     [Fact]
-    public void LogRequest_returns_a_non_empty_correlation_id()
+    public void TrackMessageRequest_returns_a_non_empty_correlation_id()
     {
         var tracker = CreateTracker();
 
-        var id = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
+        var id = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
 
         Assert.NotEqual(Guid.Empty, id);
     }
 
     [Fact]
-    public void LogRequest_sets_protocol_as_method()
+    public void TrackMessageRequest_sets_protocol_as_method()
     {
         var tracker = CreateTracker();
 
-        tracker.LogRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
+        tracker.TrackMessageRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal("EventGrid", log.Method.Value);
     }
 
     [Fact]
-    public void LogRequest_sets_destination_as_service_name()
+    public void TrackMessageRequest_sets_destination_as_service_name()
     {
         var tracker = CreateTracker();
 
-        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal("OrderService", log.ServiceName);
     }
 
     [Fact]
-    public void LogRequest_sets_calling_service_name()
+    public void TrackMessageRequest_sets_calling_service_name()
     {
         var tracker = CreateTracker(callingServiceName: "PublisherApp");
 
-        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal("PublisherApp", log.CallerName);
     }
 
     [Fact]
-    public void LogRequest_serialises_payload_as_content()
+    public void TrackMessageRequest_serialises_payload_as_content()
     {
         var tracker = CreateTracker();
 
-        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
+        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Contains("Widget", log.Content);
     }
 
     [Fact]
-    public void LogRequest_sets_uri()
+    public void TrackMessageRequest_sets_uri()
     {
         var uri = new Uri("kafka://my-topic");
         var tracker = CreateTracker();
 
-        tracker.LogRequest("Kafka", "OrderService", uri, new { });
+        tracker.TrackMessageRequest("Kafka", "OrderService", uri, new { });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal(uri, log.Uri);
     }
 
     [Fact]
-    public void LogRequest_sets_meta_type_to_event()
+    public void TrackMessageRequest_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
 
-        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal(RequestResponseMetaType.Event, log.MetaType);
     }
 
     [Fact]
-    public void LogRequest_reads_test_info_from_http_context()
+    public void TrackMessageRequest_reads_test_info_from_http_context()
     {
         var accessor = CreateHttpContextAccessor("SpecificTest", "id-42", "7c9e6679-7425-40de-944b-e07fc1f90ae7");
         var tracker = CreateTracker(accessor);
 
-        tracker.LogRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
+        tracker.TrackMessageRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
 
         var log = GetLogsFromThisTest().Single();
         Assert.Equal("SpecificTest", log.TestName);
@@ -138,15 +138,15 @@ public class MessageTrackerTests
         Assert.Equal(Guid.Parse("7c9e6679-7425-40de-944b-e07fc1f90ae7"), log.TraceId);
     }
 
-    // ─── LogResponse ────────────────────────────────────────────
+    // ─── TrackMessageResponse ───────────────────────────────────
 
     [Fact]
-    public void LogResponse_logs_a_response_entry()
+    public void TrackMessageResponse_logs_a_response_entry()
     {
         var tracker = CreateTracker();
-        var correlationId = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        tracker.LogResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
+        tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
         var logs = GetLogsFromThisTest();
         Assert.Equal(2, logs.Length);
@@ -154,48 +154,48 @@ public class MessageTrackerTests
     }
 
     [Fact]
-    public void LogResponse_uses_same_correlation_id_as_request()
+    public void TrackMessageResponse_uses_same_correlation_id_as_request()
     {
         var tracker = CreateTracker();
-        var correlationId = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+        var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        tracker.LogResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
+        tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
         var logs = GetLogsFromThisTest();
         Assert.Equal(logs[0].RequestResponseId, logs[1].RequestResponseId);
     }
 
     [Fact]
-    public void LogResponse_serialises_response_payload_when_provided()
+    public void TrackMessageResponse_serialises_response_payload_when_provided()
     {
         var tracker = CreateTracker();
-        var id = tracker.LogRequest("MQ", "Worker", new Uri("mq://queue"), new { });
+        var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
-        tracker.LogResponse("MQ", "Worker", new Uri("mq://queue"), id, new { Ack = true });
+        tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id, new { Ack = true });
 
         var responseLog = GetLogsFromThisTest().Last();
         Assert.Contains("true", responseLog.Content);
     }
 
     [Fact]
-    public void LogResponse_sets_empty_content_when_no_response_payload()
+    public void TrackMessageResponse_sets_empty_content_when_no_response_payload()
     {
         var tracker = CreateTracker();
-        var id = tracker.LogRequest("MQ", "Worker", new Uri("mq://queue"), new { });
+        var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
-        tracker.LogResponse("MQ", "Worker", new Uri("mq://queue"), id);
+        tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id);
 
         var responseLog = GetLogsFromThisTest().Last();
         Assert.Equal(string.Empty, responseLog.Content);
     }
 
     [Fact]
-    public void LogResponse_sets_meta_type_to_event()
+    public void TrackMessageResponse_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
-        var id = tracker.LogRequest("Kafka", "Svc", new Uri("kafka://t"), new { });
+        var id = tracker.TrackMessageRequest("Kafka", "Svc", new Uri("kafka://t"), new { });
 
-        tracker.LogResponse("Kafka", "Svc", new Uri("kafka://t"), id);
+        tracker.TrackMessageResponse("Kafka", "Svc", new Uri("kafka://t"), id);
 
         var responseLog = GetLogsFromThisTest().Last();
         Assert.Equal(RequestResponseMetaType.Event, responseLog.MetaType);

--- a/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
@@ -1,0 +1,203 @@
+using Microsoft.AspNetCore.Http;
+using TestTrackingDiagrams.Constants;
+using TestTrackingDiagrams.Tracking;
+
+namespace TestTrackingDiagrams.Tests.Tracking;
+
+public class MessageTrackerTests
+{
+    private readonly int _logCountBefore = RequestResponseLogger.RequestAndResponseLogs.Length;
+
+    private RequestResponseLog[] GetLogsFromThisTest()
+    {
+        return RequestResponseLogger.RequestAndResponseLogs.Skip(_logCountBefore).ToArray();
+    }
+
+    private static IHttpContextAccessor CreateHttpContextAccessor(
+        string testName = "My Test",
+        string testId = "test-id-1",
+        string traceId = "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[TestTrackingHttpHeaders.CurrentTestNameHeader] = testName;
+        context.Request.Headers[TestTrackingHttpHeaders.CurrentTestIdHeader] = testId;
+        context.Request.Headers[TestTrackingHttpHeaders.TraceIdHeader] = traceId;
+
+        return new HttpContextAccessor { HttpContext = context };
+    }
+
+    private static MessageTracker CreateTracker(
+        IHttpContextAccessor? accessor = null,
+        string callingServiceName = "MyService")
+    {
+        return new MessageTracker(accessor ?? CreateHttpContextAccessor(), callingServiceName);
+    }
+
+    // ─── LogRequest ─────────────────────────────────────────────
+
+    [Fact]
+    public void LogRequest_logs_a_request_entry()
+    {
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
+
+        var logs = GetLogsFromThisTest();
+        Assert.Single(logs);
+        Assert.Equal(RequestResponseType.Request, logs[0].Type);
+    }
+
+    [Fact]
+    public void LogRequest_returns_a_non_empty_correlation_id()
+    {
+        var tracker = CreateTracker();
+
+        var id = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
+
+        Assert.NotEqual(Guid.Empty, id);
+    }
+
+    [Fact]
+    public void LogRequest_sets_protocol_as_method()
+    {
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal("EventGrid", log.Method.Value);
+    }
+
+    [Fact]
+    public void LogRequest_sets_destination_as_service_name()
+    {
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal("OrderService", log.ServiceName);
+    }
+
+    [Fact]
+    public void LogRequest_sets_calling_service_name()
+    {
+        var tracker = CreateTracker(callingServiceName: "PublisherApp");
+
+        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal("PublisherApp", log.CallerName);
+    }
+
+    [Fact]
+    public void LogRequest_serialises_payload_as_content()
+    {
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Contains("Widget", log.Content);
+    }
+
+    [Fact]
+    public void LogRequest_sets_uri()
+    {
+        var uri = new Uri("kafka://my-topic");
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("Kafka", "OrderService", uri, new { });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal(uri, log.Uri);
+    }
+
+    [Fact]
+    public void LogRequest_sets_meta_type_to_event()
+    {
+        var tracker = CreateTracker();
+
+        tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal(RequestResponseMetaType.Event, log.MetaType);
+    }
+
+    [Fact]
+    public void LogRequest_reads_test_info_from_http_context()
+    {
+        var accessor = CreateHttpContextAccessor("SpecificTest", "id-42", "7c9e6679-7425-40de-944b-e07fc1f90ae7");
+        var tracker = CreateTracker(accessor);
+
+        tracker.LogRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
+
+        var log = GetLogsFromThisTest().Single();
+        Assert.Equal("SpecificTest", log.TestName);
+        Assert.Equal("id-42", log.TestId);
+        Assert.Equal(Guid.Parse("7c9e6679-7425-40de-944b-e07fc1f90ae7"), log.TraceId);
+    }
+
+    // ─── LogResponse ────────────────────────────────────────────
+
+    [Fact]
+    public void LogResponse_logs_a_response_entry()
+    {
+        var tracker = CreateTracker();
+        var correlationId = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+
+        tracker.LogResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Equal(2, logs.Length);
+        Assert.Equal(RequestResponseType.Response, logs[1].Type);
+    }
+
+    [Fact]
+    public void LogResponse_uses_same_correlation_id_as_request()
+    {
+        var tracker = CreateTracker();
+        var correlationId = tracker.LogRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
+
+        tracker.LogResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
+
+        var logs = GetLogsFromThisTest();
+        Assert.Equal(logs[0].RequestResponseId, logs[1].RequestResponseId);
+    }
+
+    [Fact]
+    public void LogResponse_serialises_response_payload_when_provided()
+    {
+        var tracker = CreateTracker();
+        var id = tracker.LogRequest("MQ", "Worker", new Uri("mq://queue"), new { });
+
+        tracker.LogResponse("MQ", "Worker", new Uri("mq://queue"), id, new { Ack = true });
+
+        var responseLog = GetLogsFromThisTest().Last();
+        Assert.Contains("true", responseLog.Content);
+    }
+
+    [Fact]
+    public void LogResponse_sets_empty_content_when_no_response_payload()
+    {
+        var tracker = CreateTracker();
+        var id = tracker.LogRequest("MQ", "Worker", new Uri("mq://queue"), new { });
+
+        tracker.LogResponse("MQ", "Worker", new Uri("mq://queue"), id);
+
+        var responseLog = GetLogsFromThisTest().Last();
+        Assert.Equal(string.Empty, responseLog.Content);
+    }
+
+    [Fact]
+    public void LogResponse_sets_meta_type_to_event()
+    {
+        var tracker = CreateTracker();
+        var id = tracker.LogRequest("Kafka", "Svc", new Uri("kafka://t"), new { });
+
+        tracker.LogResponse("Kafka", "Svc", new Uri("kafka://t"), id);
+
+        var responseLog = GetLogsFromThisTest().Last();
+        Assert.Equal(RequestResponseMetaType.Event, responseLog.MetaType);
+    }
+}

--- a/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/MessageTrackerTests.cs
@@ -4,13 +4,14 @@ using TestTrackingDiagrams.Tracking;
 
 namespace TestTrackingDiagrams.Tests.Tracking;
 
+[Collection("RequestResponseLogger")]
 public class MessageTrackerTests
 {
-    private readonly int _logCountBefore = RequestResponseLogger.RequestAndResponseLogs.Length;
+    private static int LogCount => RequestResponseLogger.RequestAndResponseLogs.Length;
 
-    private RequestResponseLog[] GetLogsFromThisTest()
+    private static RequestResponseLog[] GetLogsSince(int baseline)
     {
-        return RequestResponseLogger.RequestAndResponseLogs.Skip(_logCountBefore).ToArray();
+        return RequestResponseLogger.RequestAndResponseLogs.Skip(baseline).ToArray();
     }
 
     private static IHttpContextAccessor CreateHttpContextAccessor(
@@ -39,10 +40,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_logs_a_request_entry()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders-topic"), new { Id = 1 });
 
-        var logs = GetLogsFromThisTest();
+        var logs = GetLogsSince(baseline);
         Assert.Single(logs);
         Assert.Equal(RequestResponseType.Request, logs[0].Type);
     }
@@ -61,10 +63,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_protocol_as_method()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("EventGrid", "NotificationService", new Uri("eventgrid://events"), new { Msg = "hi" });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal("EventGrid", log.Method.Value);
     }
 
@@ -72,10 +75,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_destination_as_service_name()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal("OrderService", log.ServiceName);
     }
 
@@ -83,10 +87,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_calling_service_name()
     {
         var tracker = CreateTracker(callingServiceName: "PublisherApp");
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal("PublisherApp", log.CallerName);
     }
 
@@ -94,10 +99,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_serialises_payload_as_content()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { Name = "Widget" });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Contains("Widget", log.Content);
     }
 
@@ -106,10 +112,11 @@ public class MessageTrackerTests
     {
         var uri = new Uri("kafka://my-topic");
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", uri, new { });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal(uri, log.Uri);
     }
 
@@ -117,10 +124,11 @@ public class MessageTrackerTests
     public void TrackMessageRequest_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal(RequestResponseMetaType.Event, log.MetaType);
     }
 
@@ -129,10 +137,11 @@ public class MessageTrackerTests
     {
         var accessor = CreateHttpContextAccessor("SpecificTest", "id-42", "7c9e6679-7425-40de-944b-e07fc1f90ae7");
         var tracker = CreateTracker(accessor);
+        var baseline = LogCount;
 
         tracker.TrackMessageRequest("SNS", "NotifySvc", new Uri("sns://topic"), new { });
 
-        var log = GetLogsFromThisTest().Single();
+        var log = GetLogsSince(baseline).Single();
         Assert.Equal("SpecificTest", log.TestName);
         Assert.Equal("id-42", log.TestId);
         Assert.Equal(Guid.Parse("7c9e6679-7425-40de-944b-e07fc1f90ae7"), log.TraceId);
@@ -144,11 +153,12 @@ public class MessageTrackerTests
     public void TrackMessageResponse_logs_a_response_entry()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
         var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
-        var logs = GetLogsFromThisTest();
+        var logs = GetLogsSince(baseline);
         Assert.Equal(2, logs.Length);
         Assert.Equal(RequestResponseType.Response, logs[1].Type);
     }
@@ -157,11 +167,12 @@ public class MessageTrackerTests
     public void TrackMessageResponse_uses_same_correlation_id_as_request()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
         var correlationId = tracker.TrackMessageRequest("Kafka", "OrderService", new Uri("kafka://orders"), new { });
 
         tracker.TrackMessageResponse("Kafka", "OrderService", new Uri("kafka://orders"), correlationId);
 
-        var logs = GetLogsFromThisTest();
+        var logs = GetLogsSince(baseline);
         Assert.Equal(logs[0].RequestResponseId, logs[1].RequestResponseId);
     }
 
@@ -169,11 +180,12 @@ public class MessageTrackerTests
     public void TrackMessageResponse_serialises_response_payload_when_provided()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
         tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id, new { Ack = true });
 
-        var responseLog = GetLogsFromThisTest().Last();
+        var responseLog = GetLogsSince(baseline).Last();
         Assert.Contains("true", responseLog.Content);
     }
 
@@ -181,11 +193,12 @@ public class MessageTrackerTests
     public void TrackMessageResponse_sets_empty_content_when_no_response_payload()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("MQ", "Worker", new Uri("mq://queue"), new { });
 
         tracker.TrackMessageResponse("MQ", "Worker", new Uri("mq://queue"), id);
 
-        var responseLog = GetLogsFromThisTest().Last();
+        var responseLog = GetLogsSince(baseline).Last();
         Assert.Equal(string.Empty, responseLog.Content);
     }
 
@@ -193,11 +206,12 @@ public class MessageTrackerTests
     public void TrackMessageResponse_sets_meta_type_to_event()
     {
         var tracker = CreateTracker();
+        var baseline = LogCount;
         var id = tracker.TrackMessageRequest("Kafka", "Svc", new Uri("kafka://t"), new { });
 
         tracker.TrackMessageResponse("Kafka", "Svc", new Uri("kafka://t"), id);
 
-        var responseLog = GetLogsFromThisTest().Last();
+        var responseLog = GetLogsSince(baseline).Last();
         Assert.Equal(RequestResponseMetaType.Event, responseLog.MetaType);
     }
 }

--- a/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
@@ -5,6 +5,7 @@ using TestTrackingDiagrams.Tracking;
 
 namespace TestTrackingDiagrams.Tests.Tracking;
 
+[Collection("RequestResponseLogger")]
 public class TestTrackingMessageHandlerTests : IDisposable
 {
     // ─── Test infrastructure ────────────────────────────────────

--- a/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
+++ b/TestTrackingDiagrams.Tests/Tracking/TestTrackingMessageHandlerTests.cs
@@ -5,7 +5,6 @@ using TestTrackingDiagrams.Tracking;
 
 namespace TestTrackingDiagrams.Tests.Tracking;
 
-[Collection("RequestResponseLogger")]
 public class TestTrackingMessageHandlerTests : IDisposable
 {
     // ─── Test infrastructure ────────────────────────────────────
@@ -27,13 +26,13 @@ public class TestTrackingMessageHandlerTests : IDisposable
     }
 
     private readonly StubInnerHandler _innerHandler = new();
-
-    /// <summary>Snapshot of log count before this test, so we only inspect logs we generated.</summary>
-    private readonly int _logCountBefore = RequestResponseLogger.RequestAndResponseLogs.Length;
+    private readonly string _testId = Guid.NewGuid().ToString();
 
     private RequestResponseLog[] GetLogsFromThisTest()
     {
-        return RequestResponseLogger.RequestAndResponseLogs.Skip(_logCountBefore).ToArray();
+        return RequestResponseLogger.RequestAndResponseLogs
+            .Where(l => l.TestId == _testId)
+            .ToArray();
     }
 
     private HttpMessageInvoker CreateInvoker(TestTrackingMessageHandlerOptions options, IHttpContextAccessor? httpContextAccessor = null)
@@ -45,13 +44,13 @@ public class TestTrackingMessageHandlerTests : IDisposable
         return new HttpMessageInvoker(handler);
     }
 
-    private static TestTrackingMessageHandlerOptions DefaultOptions(
+    private TestTrackingMessageHandlerOptions DefaultOptions(
         string callerName = "TestCaller",
         string? fixedServiceName = "TargetService") => new()
     {
         CallingServiceName = callerName,
         FixedNameForReceivingService = fixedServiceName,
-        CurrentTestInfoFetcher = () => ("My Test", "test-id-1"),
+        CurrentTestInfoFetcher = () => ("My Test", _testId),
     };
 
     private static HttpRequestMessage MakeGetRequest(string url = "http://target-service:5000/api/items")
@@ -173,7 +172,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             FixedNameForReceivingService = "Svc",
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Fetched Test Name", "fetched-test-id"),
+            CurrentTestInfoFetcher = () => ("Fetched Test Name", _testId),
         };
         using var invoker = CreateInvoker(options);
 
@@ -181,7 +180,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
 
         var requestLog = GetLogsFromThisTest().First(l => l.Type == RequestResponseType.Request);
         Assert.Equal("Fetched Test Name", requestLog.TestName);
-        Assert.Equal("fetched-test-id", requestLog.TestId);
+        Assert.Equal(_testId, requestLog.TestId);
     }
 
     // ─── Service name resolution ────────────────────────────────
@@ -205,7 +204,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             PortsToServiceNames = new Dictionary<int, string> { { 5000, "MappedService" } },
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Test", "id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
         };
         using var invoker = CreateInvoker(options);
 
@@ -222,7 +221,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             PortsToServiceNames = new Dictionary<int, string> { { 9999, "Other" } },
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Test", "id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
         };
         using var invoker = CreateInvoker(options);
 
@@ -399,7 +398,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
     {
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Context Test Name"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "context-test-id"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         var options = DefaultOptions();
         using var invoker = CreateInvoker(options, accessor);
 
@@ -407,7 +406,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
 
         var requestLog = GetLogsFromThisTest().First(l => l.Type == RequestResponseType.Request);
         Assert.Equal("Context Test Name", requestLog.TestName);
-        Assert.Equal("context-test-id", requestLog.TestId);
+        Assert.Equal(_testId, requestLog.TestId);
     }
 
     [Fact]
@@ -417,7 +416,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.TraceIdHeader, traceGuid.ToString()),
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "id-1"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(DefaultOptions(), accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -433,7 +432,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.TraceIdHeader, traceGuid.ToString()),
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "id-1"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(DefaultOptions(), accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -454,7 +453,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CallerNameHeader, "UpstreamCaller"),
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "id-1"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(DefaultOptions(), accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -475,7 +474,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             FixedNameForReceivingService = "Svc",
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Fetcher Test", "fetcher-id"),
+            CurrentTestInfoFetcher = () => ("Fetcher Test", _testId),
         };
         using var invoker = CreateInvoker(options, httpContextAccessor: null);
 
@@ -483,7 +482,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
 
         var requestLog = GetLogsFromThisTest().First(l => l.Type == RequestResponseType.Request);
         Assert.Equal("Fetcher Test", requestLog.TestName);
-        Assert.Equal("fetcher-id", requestLog.TestId);
+        Assert.Equal(_testId, requestLog.TestId);
         Assert.NotEqual(Guid.Empty, requestLog.TraceId);
     }
 
@@ -610,7 +609,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
     {
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Existing Name"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "existing-id"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(DefaultOptions(), accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -630,7 +629,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
     {
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "existing-id-from-context"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(DefaultOptions(), accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -640,7 +639,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
 
         // But the log still uses the value from context
         var requestLog = GetLogsFromThisTest().First(l => l.Type == RequestResponseType.Request);
-        Assert.Equal("existing-id-from-context", requestLog.TestId);
+        Assert.Equal(_testId, requestLog.TestId);
     }
 
     // ─── Port-based service name with multiple mappings ─────────
@@ -656,7 +655,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
                 { 5002, "ServiceB" },
             },
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Test", "id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
         };
 
         using var invoker = CreateInvoker(options);
@@ -735,7 +734,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             FixedNameForReceivingService = "Svc",
             CallingServiceName = "Caller",
-            CurrentTestInfoFetcher = () => ("Test", "id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
             HeadersToForward = ["X-Something"],
         };
         using var invoker = CreateInvoker(options, accessor);
@@ -894,7 +893,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
     {
         CallingServiceName = "Caller",
         FixedNameForReceivingService = "Svc",
-        CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+        CurrentTestInfoFetcher = () => ("Test", _testId),
         CurrentStepTypeFetcher = stepTypeFetcher,
     };
 
@@ -1145,7 +1144,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
 
         var marker = GetLogsFromThisTest().Single(l => l.IsActionStart);
-        Assert.Equal("test-id-1", marker.TestId);
+        Assert.Equal(_testId, marker.TestId);
     }
 
     [Fact]
@@ -1156,7 +1155,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             CallingServiceName = "Caller",
             FixedNameForReceivingService = "Svc",
-            CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
             CurrentStepTypeFetcher = () =>
             {
                 stepFetcherCalled = true;
@@ -1165,7 +1164,7 @@ public class TestTrackingMessageHandlerTests : IDisposable
         };
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Server Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "server-id"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(options, accessor);
 
         await invoker.SendAsync(MakeGetRequest(), CancellationToken.None);
@@ -1181,12 +1180,12 @@ public class TestTrackingMessageHandlerTests : IDisposable
         {
             CallingServiceName = "Caller",
             FixedNameForReceivingService = "Svc",
-            CurrentTestInfoFetcher = () => ("Test", "test-id-1"),
+            CurrentTestInfoFetcher = () => ("Test", _testId),
             CurrentStepTypeFetcher = () => throw new InvalidOperationException("Not in scenario context"),
         };
         var accessor = CreateHttpContextAccessor(
             (TestTrackingHttpHeaders.CurrentTestNameHeader, "Server Test"),
-            (TestTrackingHttpHeaders.CurrentTestIdHeader, "server-id"));
+            (TestTrackingHttpHeaders.CurrentTestIdHeader, _testId));
         using var invoker = CreateInvoker(options, accessor);
 
         // Should NOT throw — the fetcher is never called on the server side

--- a/TestTrackingDiagrams/Reports/Feature.cs
+++ b/TestTrackingDiagrams/Reports/Feature.cs
@@ -2,7 +2,7 @@
 
 public record Feature
 {
-    public string DisplayName { get; set; }
+    public required string DisplayName { get; set; }
     public string? Endpoint { get; set; }
     public Scenario[] Scenarios { get; set; } = [];
 }

--- a/TestTrackingDiagrams/Reports/Scenario.cs
+++ b/TestTrackingDiagrams/Reports/Scenario.cs
@@ -2,8 +2,8 @@
 
 public record Scenario
 {
-    public string Id { get; set; }
-    public string DisplayName { get; set; }
+    public required string Id { get; set; }
+    public required string DisplayName { get; set; }
     public bool IsHappyPath { get; set; }
     public ScenarioResult Result { get; set; }
     public string? ErrorMessage { get; set; }

--- a/TestTrackingDiagrams/Tracking/MessageTracker.cs
+++ b/TestTrackingDiagrams/Tracking/MessageTracker.cs
@@ -30,14 +30,14 @@ public class MessageTracker
 
     /// <summary>
     /// Logs a request entry for a message being sent to a named destination.
-    /// Returns a correlation ID to pass to <see cref="LogResponse"/>.
+    /// Returns a correlation ID to pass to <see cref="TrackMessageResponse"/>.
     /// </summary>
     /// <param name="protocol">The protocol or transport label shown in the diagram (e.g. "Kafka", "EventGrid", "SNS", "RabbitMQ").</param>
     /// <param name="destinationName">The name of the destination service or topic shown in the diagram.</param>
     /// <param name="destinationUri">A URI representing the destination (e.g. <c>new Uri("kafka://orders-topic")</c>).</param>
     /// <param name="payload">The message payload. Will be JSON-serialised and shown in the diagram note.</param>
-    /// <returns>A correlation ID that must be passed to <see cref="LogResponse"/> to pair the request and response.</returns>
-    public Guid LogRequest(string protocol, string destinationName, Uri destinationUri, object payload)
+    /// <returns>A correlation ID that must be passed to <see cref="TrackMessageResponse"/> to pair the request and response.</returns>
+    public Guid TrackMessageRequest(string protocol, string destinationName, Uri destinationUri, object payload)
     {
         var requestResponseId = Guid.NewGuid();
         var content = JsonSerializer.Serialize(payload, _serializerOptions);
@@ -65,12 +65,12 @@ public class MessageTracker
     /// <summary>
     /// Logs a response entry for a message that was sent.
     /// </summary>
-    /// <param name="protocol">The protocol or transport label (must match the value passed to <see cref="LogRequest"/>).</param>
-    /// <param name="destinationName">The destination service or topic name (must match the value passed to <see cref="LogRequest"/>).</param>
-    /// <param name="destinationUri">The destination URI (must match the value passed to <see cref="LogRequest"/>).</param>
-    /// <param name="requestResponseId">The correlation ID returned by <see cref="LogRequest"/>.</param>
+    /// <param name="protocol">The protocol or transport label (must match the value passed to <see cref="TrackMessageRequest"/>).</param>
+    /// <param name="destinationName">The destination service or topic name (must match the value passed to <see cref="TrackMessageRequest"/>).</param>
+    /// <param name="destinationUri">The destination URI (must match the value passed to <see cref="TrackMessageRequest"/>).</param>
+    /// <param name="requestResponseId">The correlation ID returned by <see cref="TrackMessageRequest"/>.</param>
     /// <param name="responsePayload">Optional response payload (e.g. an acknowledgement). Will be JSON-serialised if provided.</param>
-    public void LogResponse(string protocol, string destinationName, Uri destinationUri, Guid requestResponseId, object? responsePayload = null)
+    public void TrackMessageResponse(string protocol, string destinationName, Uri destinationUri, Guid requestResponseId, object? responsePayload = null)
     {
         var content = responsePayload is not null
             ? JsonSerializer.Serialize(responsePayload, _serializerOptions)

--- a/TestTrackingDiagrams/Tracking/MessageTracker.cs
+++ b/TestTrackingDiagrams/Tracking/MessageTracker.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using TestTrackingDiagrams.Constants;
+
+namespace TestTrackingDiagrams.Tracking;
+
+/// <summary>
+/// Logs non-HTTP interactions (events, messages, commands) to the
+/// <see cref="RequestResponseLogger"/> so they appear in the PlantUML
+/// sequence diagrams alongside regular HTTP traffic.
+///
+/// Register an instance in DI (typically as a singleton) and inject it
+/// into any fake or stub that simulates publishing/sending messages.
+/// </summary>
+public class MessageTracker
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly string _callingServiceName;
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public MessageTracker(
+        IHttpContextAccessor httpContextAccessor,
+        string callingServiceName,
+        JsonSerializerOptions? serializerOptions = null)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _callingServiceName = callingServiceName;
+        _serializerOptions = serializerOptions ?? new JsonSerializerOptions();
+    }
+
+    /// <summary>
+    /// Logs a request entry for a message being sent to a named destination.
+    /// Returns a correlation ID to pass to <see cref="LogResponse"/>.
+    /// </summary>
+    /// <param name="protocol">The protocol or transport label shown in the diagram (e.g. "Kafka", "EventGrid", "SNS", "RabbitMQ").</param>
+    /// <param name="destinationName">The name of the destination service or topic shown in the diagram.</param>
+    /// <param name="destinationUri">A URI representing the destination (e.g. <c>new Uri("kafka://orders-topic")</c>).</param>
+    /// <param name="payload">The message payload. Will be JSON-serialised and shown in the diagram note.</param>
+    /// <returns>A correlation ID that must be passed to <see cref="LogResponse"/> to pair the request and response.</returns>
+    public Guid LogRequest(string protocol, string destinationName, Uri destinationUri, object payload)
+    {
+        var requestResponseId = Guid.NewGuid();
+        var content = JsonSerializer.Serialize(payload, _serializerOptions);
+        var testInfo = GetTestInfo();
+
+        RequestResponseLogger.Log(new RequestResponseLog(
+            testInfo.TestName,
+            testInfo.TestId,
+            protocol,
+            content,
+            destinationUri,
+            [],
+            destinationName,
+            _callingServiceName,
+            RequestResponseType.Request,
+            testInfo.TraceId,
+            requestResponseId,
+            false,
+            MetaType: RequestResponseMetaType.Event
+        ));
+
+        return requestResponseId;
+    }
+
+    /// <summary>
+    /// Logs a response entry for a message that was sent.
+    /// </summary>
+    /// <param name="protocol">The protocol or transport label (must match the value passed to <see cref="LogRequest"/>).</param>
+    /// <param name="destinationName">The destination service or topic name (must match the value passed to <see cref="LogRequest"/>).</param>
+    /// <param name="destinationUri">The destination URI (must match the value passed to <see cref="LogRequest"/>).</param>
+    /// <param name="requestResponseId">The correlation ID returned by <see cref="LogRequest"/>.</param>
+    /// <param name="responsePayload">Optional response payload (e.g. an acknowledgement). Will be JSON-serialised if provided.</param>
+    public void LogResponse(string protocol, string destinationName, Uri destinationUri, Guid requestResponseId, object? responsePayload = null)
+    {
+        var content = responsePayload is not null
+            ? JsonSerializer.Serialize(responsePayload, _serializerOptions)
+            : string.Empty;
+        var testInfo = GetTestInfo();
+
+        RequestResponseLogger.Log(new RequestResponseLog(
+            testInfo.TestName,
+            testInfo.TestId,
+            protocol,
+            content,
+            destinationUri,
+            [],
+            destinationName,
+            _callingServiceName,
+            RequestResponseType.Response,
+            testInfo.TraceId,
+            requestResponseId,
+            false,
+            "Responded",
+            MetaType: RequestResponseMetaType.Event
+        ));
+    }
+
+    private (string TestName, string TestId, Guid TraceId) GetTestInfo()
+    {
+        var headers = _httpContextAccessor.HttpContext!.Request.Headers;
+
+        headers.TryGetValue(TestTrackingHttpHeaders.CurrentTestNameHeader, out var testNameValues);
+        headers.TryGetValue(TestTrackingHttpHeaders.CurrentTestIdHeader, out var testIdValues);
+        headers.TryGetValue(TestTrackingHttpHeaders.TraceIdHeader, out var traceIdValues);
+
+        return (
+            testNameValues.First()!,
+            testIdValues.First()!,
+            Guid.Parse(traceIdValues.First()!)
+        );
+    }
+}

--- a/TestTrackingDiagrams/Tracking/ServiceCollectionExtensions.cs
+++ b/TestTrackingDiagrams/Tracking/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace TestTrackingDiagrams.Tracking;
 
@@ -9,6 +11,20 @@ public static class ServiceCollectionHelper
         services.AddSingleton(options);
         services.AddHttpContextAccessor();
         services.AddSingleton<IHttpClientFactory, TestTrackingHttpClientFactory>();
+
+        return services;
+    }
+
+    public static IServiceCollection TrackMessagesForDiagrams(
+        this IServiceCollection services,
+        string callingServiceName,
+        JsonSerializerOptions? serializerOptions = null)
+    {
+        services.AddHttpContextAccessor();
+        services.AddSingleton(sp => new MessageTracker(
+            sp.GetRequiredService<IHttpContextAccessor>(),
+            callingServiceName,
+            serializerOptions));
 
         return services;
     }

--- a/TestTrackingDiagrams/Tracking/TestTrackingMessageHandler.cs
+++ b/TestTrackingDiagrams/Tracking/TestTrackingMessageHandler.cs
@@ -44,7 +44,7 @@ public class TestTrackingMessageHandler : DelegatingHandler
         var requestResponseId = Guid.NewGuid();
 
         var requestContentString = request.Content is null ? null : await request.Content!.ReadAsStringAsync(cancellationToken);
-        var requestHeaders = request.Headers.SelectMany(x => x.Value.Select(value => (x.Key, value))).ToArray();
+        var requestHeaders = request.Headers.SelectMany(x => x.Value.Select(value => (x.Key, (string?)value))).ToArray();
 
         StringValues currentTestNameHeaders = new();
         var hasCurrentTestNameHeader = false;
@@ -66,25 +66,25 @@ public class TestTrackingMessageHandler : DelegatingHandler
             hasCallerNameHeader = _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(TestTrackingHttpHeaders.CallerNameHeader, out callerNameHeaders);
         }
 
-        var currentTestInfoFetcher = hasCurrentTestNameHeader ? () => (currentTestNameHeaders.First(), currentTestIdHeaders.First()) : _currentTestInfoFetcher;
+        var currentTestInfoFetcher = hasCurrentTestNameHeader ? () => (currentTestNameHeaders.First()!, currentTestIdHeaders.First()!) : _currentTestInfoFetcher;
 
-        var traceId = hasTraceIdHeader ? Guid.Parse(traceIdHeaders.First()) : Guid.NewGuid();
+        var traceId = hasTraceIdHeader ? Guid.Parse(traceIdHeaders.First()!) : Guid.NewGuid();
 
         if (!hasTraceIdHeader)
             request.Headers.Add(TestTrackingHttpHeaders.TraceIdHeader, new[] { traceId.ToString() });
 
         if (!hasCurrentTestNameHeader)
-            request.Headers.Add(TestTrackingHttpHeaders.CurrentTestNameHeader, new[] { currentTestInfoFetcher().Name });
+            request.Headers.Add(TestTrackingHttpHeaders.CurrentTestNameHeader, new[] { currentTestInfoFetcher!().Name });
 
         if (!hasCurrentTestIdHeader)
-            request.Headers.Add(TestTrackingHttpHeaders.CurrentTestIdHeader, new[] { currentTestInfoFetcher().Id.ToString() });
+            request.Headers.Add(TestTrackingHttpHeaders.CurrentTestIdHeader, new[] { currentTestInfoFetcher!().Id.ToString() });
 
         if (!hasCallerNameHeader)
-            request.Headers.Add(TestTrackingHttpHeaders.CallerNameHeader, new[] { _callingServiceName });
+            request.Headers.Add(TestTrackingHttpHeaders.CallerNameHeader, new[] { _callingServiceName! });
 
-        var currentTestInfo = currentTestInfoFetcher();
+        var currentTestInfo = currentTestInfoFetcher!();
 
-        var serviceName = _getServiceNameFromPortTranslator(request.RequestUri.Port);
+        var serviceName = _getServiceNameFromPortTranslator(request.RequestUri!.Port);
 
         if (!hasCurrentTestNameHeader)
             InjectImplicitActionStartIfNeeded(currentTestInfo);
@@ -97,7 +97,7 @@ public class TestTrackingMessageHandler : DelegatingHandler
             request.RequestUri!,
             requestHeaders,
             serviceName,
-            _callingServiceName,
+            _callingServiceName!,
             RequestResponseType.Request,
             traceId,
             requestResponseId,
@@ -107,7 +107,7 @@ public class TestTrackingMessageHandler : DelegatingHandler
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
         var responseContentString = await response.Content.ReadAsStringAsync(cancellationToken);
-        var responseHeaders = response.Headers.SelectMany(x => x.Value.Select(value => (x.Key, value))).ToArray();
+        var responseHeaders = response.Headers.SelectMany(x => x.Value.Select(value => (x.Key, (string?)value))).ToArray();
 
         RequestResponseLogger.Log(new RequestResponseLog(
             currentTestInfo.Name,
@@ -117,7 +117,7 @@ public class TestTrackingMessageHandler : DelegatingHandler
             request.RequestUri!,
             responseHeaders,
             serviceName,
-            _callingServiceName,
+            _callingServiceName!,
             RequestResponseType.Response,
             traceId,
             requestResponseId,


### PR DESCRIPTION
- New MessageTracker class in core library (TestTrackingDiagrams.Tracking)
- Logs events, messages, and commands to sequence diagrams
- Supports any protocol: Kafka, EventGrid, SNS, RabbitMQ, etc.
- Reads test info from IHttpContextAccessor tracking headers
- LogRequest returns correlation ID, LogResponse completes the pair
- 14 unit tests covering all functionality